### PR TITLE
fix(onboarding): improve province selection

### DIFF
--- a/web/src/components/layout/OptionPickerSheet.vue
+++ b/web/src/components/layout/OptionPickerSheet.vue
@@ -1,0 +1,102 @@
+<template>
+  <BottomSheet
+    :model-value="modelValue"
+    :title="title"
+    :subtitle="subtitle"
+    variant="form"
+    @update:model-value="$emit('update:modelValue', $event)"
+  >
+    <div class="option-picker-grid" role="listbox" :aria-label="title">
+      <button
+        v-for="option in options"
+        :key="option.value"
+        type="button"
+        :class="{ active: option.value === value }"
+        role="option"
+        :aria-selected="option.value === value"
+        @click="select(option.value)"
+      >
+        <span>{{ option.label }}</span>
+        <CheckIcon v-if="option.value === value" />
+      </button>
+    </div>
+  </BottomSheet>
+</template>
+
+<script setup lang="ts">
+import { CheckIcon } from 'lucide-vue-next';
+import BottomSheet from './BottomSheet.vue';
+
+defineProps<{
+  modelValue: boolean;
+  value: string;
+  title: string;
+  subtitle?: string;
+  options: readonly { readonly value: string; readonly label: string }[];
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean];
+  select: [value: string];
+}>();
+
+function select(value: string) {
+  emit('select', value);
+  emit('update:modelValue', false);
+}
+</script>
+
+<style scoped>
+.option-picker-grid {
+  max-height: min(44dvh, 390px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  padding: 2px 0 4px;
+  -webkit-overflow-scrolling: touch;
+}
+
+.option-picker-grid button {
+  min-width: 0;
+  min-height: 42px;
+  border: none;
+  border-radius: var(--radius-control);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 0 7px;
+  background: var(--surface-control);
+  color: var(--text-secondary-color);
+  font: inherit;
+  font-size: var(--type-size-secondary);
+  font-weight: var(--type-weight-medium);
+}
+
+.option-picker-grid button span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.option-picker-grid button svg {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+}
+
+.option-picker-grid button.active {
+  background: rgba(var(--color-brand-rgb), .13);
+  color: var(--primary-color);
+  font-weight: var(--type-weight-semibold);
+}
+
+@media (max-width: 360px) {
+  .option-picker-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+</style>

--- a/web/src/features/onboarding/OnboardingView.vue
+++ b/web/src/features/onboarding/OnboardingView.vue
@@ -45,17 +45,11 @@
             />
           </FormField>
           <FormField label="报考地区">
-            <div class="province-picker" role="listbox" aria-label="报考地区">
-              <button
-                v-for="item in provinceOptions"
-                :key="item.value"
-                type="button"
-                :class="{ active: form.province === item.value }"
-                @click="selectProvince(item.value)"
-              >
-                {{ item.label }}
-              </button>
-            </div>
+            <ProvincePickerControl
+              v-model="form.province"
+              :national="form.examScope === 'national'"
+              :options="provincialProvinceOptions"
+            />
           </FormField>
         </div>
         <FormField label="目标岗位" hint="可选，只用于调整岗位匹配和备考建议">
@@ -154,7 +148,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
+import { onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import {
   CalendarClockIcon,
@@ -177,6 +171,7 @@ import {
 import type { JsonObject, LocalDate, SubjectCode, TimeZoneId } from '@/kernel/public';
 import { OnboardingMessage, resolveOnboardingError } from './onboardingMessages';
 import { OnboardingDraftFeature } from './OnboardingDraftFeature';
+import ProvincePickerControl from './ProvincePickerControl.vue';
 
 const OnboardingStep = {
   Goal: 1,
@@ -238,13 +233,9 @@ const proactiveOptions = [
   { value: ProactiveLevel.Active, label: '主动督学' }
 ] as const;
 const provincialProvinceOptions = PROVINCE_OPTIONS.map((name) => ({ value: name, label: name }));
-const provinceOptions = computed(() => (
-  form.examScope === 'national'
-    ? [{ value: '全国', label: '全国' }]
-    : provincialProvinceOptions
-));
+watch(() => form.examScope, normalizeProvince, { immediate: true });
 
-watch(() => form.examScope, (scope) => {
+function normalizeProvince(scope: string) {
   if (scope === 'national') {
     form.province = '全国';
     return;
@@ -252,7 +243,7 @@ watch(() => form.examScope, (scope) => {
   if (!provincialProvinceOptions.some((item) => item.value === form.province)) {
     form.province = '江西';
   }
-}, { immediate: true });
+}
 
 onMounted(async () => {
   await restoreDraft();
@@ -283,6 +274,7 @@ async function restoreDraft() {
         (form[key] as string | number) = value as string | number;
       }
     }
+    normalizeProvince(form.examScope);
   } catch {
     submitMessage.value = OnboardingMessage.SaveFailed;
   }
@@ -312,10 +304,6 @@ function draftFeature(): Promise<OnboardingDraftFeature> {
 
 function goToStep(target: number) {
   if (target <= step.value || validateStep(step.value)) step.value = target;
-}
-
-function selectProvince(value: string) {
-  form.province = value;
 }
 
 function nextStep() {
@@ -556,33 +544,6 @@ function isValidLocalDate(value: string): boolean {
 .date-text-input {
   letter-spacing: .02em;
   font-variant-numeric: tabular-nums;
-}
-
-.province-picker {
-  max-height: 94px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
-.province-picker button {
-  min-width: 54px;
-  min-height: 31px;
-  border: none;
-  border-radius: 999px;
-  padding: 0 10px;
-  background: var(--surface-control);
-  color: var(--text-secondary-color);
-  font: inherit;
-  font-size: var(--type-size-caption);
-  font-weight: var(--type-weight-semibold);
-}
-
-.province-picker button.active {
-  background: rgba(var(--color-brand-rgb), .12);
-  color: var(--primary-color);
 }
 
 .score-block {

--- a/web/src/features/onboarding/ProvincePickerControl.vue
+++ b/web/src/features/onboarding/ProvincePickerControl.vue
@@ -1,0 +1,80 @@
+<template>
+  <button
+    class="province-select-trigger"
+    type="button"
+    :disabled="national"
+    :aria-label="national ? '国考地区固定为全国' : `当前报考地区：${modelValue}`"
+    @click="open = true"
+  >
+    <MapPinIcon />
+    <span>{{ modelValue || '选择省份' }}</span>
+    <ChevronDownIcon v-if="!national" />
+  </button>
+
+  <OptionPickerSheet
+    v-model="open"
+    :value="modelValue"
+    title="选择报考省份"
+    subtitle="用于匹配省考范围、真题和政策信息"
+    :options="options"
+    @select="$emit('update:modelValue', $event)"
+  />
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { ChevronDownIcon, MapPinIcon } from 'lucide-vue-next';
+import OptionPickerSheet from '@/components/layout/OptionPickerSheet.vue';
+
+const props = defineProps<{
+  modelValue: string;
+  national: boolean;
+  options: readonly { readonly value: string; readonly label: string }[];
+}>();
+
+defineEmits<{
+  'update:modelValue': [value: string];
+}>();
+
+const open = ref(false);
+watch(() => props.national, (national) => {
+  if (national) open.value = false;
+});
+</script>
+
+<style scoped>
+.province-select-trigger {
+  width: 100%;
+  min-height: 44px;
+  border: none;
+  border-radius: var(--radius-control);
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) 16px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  background: var(--surface-control);
+  color: var(--text-color);
+  font: inherit;
+  font-size: var(--type-size-body);
+  text-align: left;
+}
+
+.province-select-trigger svg {
+  width: 17px;
+  height: 17px;
+  color: var(--primary-color);
+}
+
+.province-select-trigger span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.province-select-trigger:disabled {
+  grid-template-columns: 18px minmax(0, 1fr);
+  opacity: .72;
+}
+</style>


### PR DESCRIPTION
## User feedback

Hands-on iPhone testing showed that all 31 provinces were rendered inside a half-width, internally scrollable form field. The touch targets were small, provinces were difficult to locate, and the national/provincial exam behavior was not sufficiently clear.

Closes #7

## Root cause

The onboarding page owned the province data, selection state, and the concrete layout for all 31 option chips. The project lacked a mobile-oriented component for bounded option sets, and restored drafts were not normalized after hydration.

## Changes

- Add a reusable `OptionPickerSheet` with a stable grid, bounded internal scrolling, and selected-state feedback.
- Add `ProvincePickerControl` to encapsulate onboarding-specific behavior.
- Lock national exams to “Nationwide”; only provincial exams can open the picker.
- Normalize province values after restoring an onboarding draft.
- Remove the page-specific chip list and its dedicated styles.

## Scope and risk

- No database schema, exam-cycle use case, provider, or Agent behavior changes.
- The change is limited to onboarding input interaction.
- iOS touch and safe-area validation remains pending, so the `needs:device-validation` label stays in place.

## Verification

- [x] `npm run check:onboarding`
- [x] `npm run check:design`
- [x] `npm --prefix web run typecheck`
- [x] `npm run web:build`
- [x] GitHub Actions CI
- [ ] iOS device regression

## Review focus

Please check the four-column/three-column small-screen layout, bottom safe area, disabled national-exam state, and restored-draft normalization.