### PR TITLE
Adopt MIT license and bilingual governance docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,13 @@
 # Code of Conduct
 
-Civil AI 社区致力于提供开放、友善、无骚扰的协作环境。
+Civil AI is committed to an open, welcoming, and harassment-free collaboration environment.
 
-参与者应尊重不同背景和观点，专注于技术与用户价值，给予建设性反馈，并保护用户隐私。侮辱、威胁、歧视、骚扰、泄露他人隐私或持续扰乱协作的行为不可接受。
+Participants must respect different backgrounds and viewpoints, focus feedback on technical work and user value, communicate constructively, and protect user privacy. Insults, threats, discrimination, harassment, disclosure of another person's private information, or persistent disruption are not acceptable.
 
-维护者可以编辑、拒绝或删除违反本准则的内容，并对严重或持续违规者限制参与。需要报告社区行为问题时，请通过 GitHub 私密渠道联系维护者；维护者会尽可能保护报告者身份。
+Maintainers may edit, reject, or remove content that violates this policy and may restrict participation for serious or repeated violations. Report conduct concerns through a private GitHub channel whenever possible. Maintainers will make reasonable efforts to protect the reporter's identity.
+
+## 中文说明
+
+Civil AI 社区致力于提供开放、友善、无骚扰的协作环境。参与者应尊重不同背景和观点，专注于技术与用户价值，给予建设性反馈，并保护用户隐私。
+
+侮辱、威胁、歧视、骚扰、泄露他人隐私或持续扰乱协作的行为不可接受。维护者可以处理违反本准则的内容，并对严重或持续违规者限制参与。请尽量通过 GitHub 私密渠道报告社区行为问题。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,4 +84,4 @@ For user-facing changes, include screenshots or a short recording and state whic
 
 Maintainers review correctness, architecture boundaries, user impact, security, accessibility, and test coverage. A merged change is included in a release only after the release gate passes and the public changelog is updated.
 
-By contributing, you confirm that you have the right to provide the contribution under the project's ISC License and agree to follow the [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+By contributing, you confirm that you have the right to provide the contribution under the project's MIT License and agree to follow the [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,21 @@
-ISC License
+MIT License
 
 Copyright (c) 2026 zhangl1001
 
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,4 +4,8 @@
 
 - [@zhangl1001](https://github.com/zhangl1001) — architecture, releases, security and project direction
 
+Maintainers are responsible for Issue triage, Pull Request review, release management, security response, and roadmap stewardship. As the community grows, contributors with a sustained record of high-quality work may be invited to become core maintainers.
+
+## 中文说明
+
 维护者负责 Issue 分流、Pull Request Review、发布管理、安全响应和项目路线维护。随着社区成长，持续做出高质量贡献的参与者可以受邀成为 core maintainer。

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Civil AI
 
 [![CI](https://github.com/zhangl1001/civil-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/zhangl1001/civil-ai/actions/workflows/ci.yml)
-[![License: ISC](https://img.shields.io/badge/license-ISC-blue.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Vue 3](https://img.shields.io/badge/Vue-3-42b883.svg)](web/package.json)
 [![iOS](https://img.shields.io/badge/iOS-Capacitor-lightgrey.svg)](ios/App/App.xcodeproj)
 
@@ -141,4 +141,4 @@ Issues and pull requests are welcome. Read [`CONTRIBUTING.md`](CONTRIBUTING.md),
 
 ## License
 
-Civil AI is available under the [ISC License](LICENSE).
+Civil AI is available under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,18 @@
 
 ## Supported versions
 
-安全修复仅面向最新的 `main` 分支和最新发布版本。
+Security fixes are provided for the latest `main` branch and the most recent release.
 
 ## Reporting a vulnerability
 
-请不要为安全漏洞创建公开 Issue，也不要附上真实 API Key、用户数据或可直接利用的公开 PoC。
+Do not open a public Issue for a vulnerability. Do not include real API keys, user data, signing material, or a directly exploitable public proof of concept.
 
-请通过 GitHub 仓库的 **Security → Report a vulnerability** 私密报告功能联系维护者。报告应包含受影响版本、影响范围、最小复现步骤和建议修复方向。维护者会尽快确认收到，并在完成影响评估后协调披露时间。
+Use the repository's **Security -> Report a vulnerability** flow to contact the maintainer privately. Include the affected version, impact, minimal reproduction steps, and any proposed remediation. The maintainer will acknowledge the report as soon as practical, assess its scope, and coordinate disclosure after a fix is available.
 
-如果 GitHub 私密漏洞报告暂不可用，请先创建不包含漏洞细节的普通 Issue，请求维护者提供私密沟通渠道。
+If GitHub private vulnerability reporting is unavailable, open a public Issue without vulnerability details and ask the maintainer to provide a private contact channel.
+
+## 中文说明
+
+安全修复面向最新的 `main` 分支和最新发布版本。请勿为安全漏洞创建公开 Issue，也不要公开真实 API Key、用户数据、签名材料或可直接利用的 PoC。
+
+请优先使用仓库的 **Security -> Report a vulnerability** 功能私密报告，并提供受影响版本、影响范围、最小复现步骤和建议修复方向。如果该功能不可用，可创建不包含漏洞细节的普通 Issue，请求维护者提供私密沟通渠道。

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "zhangl-agent",
       "version": "1.2.0",
       "hasInstallScript": true,
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@capacitor-community/sqlite": "^8.1.0",
         "@capacitor/cli": "^8.4.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "vue"
   ],
   "author": "zhangl1001",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "@capacitor-community/sqlite": "^8.1.0",
     "@capacitor/cli": "^8.4.1",


### PR DESCRIPTION
## Summary

- replace the ISC license with the MIT license
- update package metadata and README license references
- make the security policy, code of conduct, and maintainer guidance English-first with Chinese translations

## Why

Use a widely recognized permissive license and make public governance documentation accessible to both international reviewers and Chinese-speaking contributors.

## Verification

- checked all tracked public files for stale ISC references
- verified `package.json` and `package-lock.json` both declare MIT
- ran `git diff --check`

The unrelated local Xcode signing change is not included.