### PR TITLE
Fix essay question-set identity and lifecycle isolation

### DIFF
--- a/scripts/verify-essay-question-set-classification.mjs
+++ b/scripts/verify-essay-question-set-classification.mjs
@@ -23,7 +23,7 @@ try {
 
   verifyIdentityAndTaskScope(identity, tasks);
   verifyNavigation(navigation);
-  await verifyClassificationAndOrdering(featureModule);
+  await verifyClassificationAndOrdering(featureModule, identity);
   await verifyHistorySummaryQuery(repositoryModule);
 
   console.log('Essay question-set classification verification passed.');
@@ -36,7 +36,7 @@ function verifyIdentityAndTaskScope(identity, tasks) {
   const secondId = identity.createEssayQuestionSetId();
   assert.notEqual(firstId, secondId);
 
-  const context = { date: '2026-08-12', topic: '归纳概括', type: 'short', entryMode: 'tutor' };
+  const context = { date: '2026-08-12', topic: '归纳概括', type: 'short', entryMode: 'tutor', purpose: 'practice' };
   const scope = identity.essayQuestionSetGenerationScope(context);
   assert.equal(
     tasks.generationTaskScope('project-1', { intent: 'mock', sourceId: firstId, scopeId: scope }),
@@ -44,13 +44,29 @@ function verifyIdentityAndTaskScope(identity, tasks) {
     'output identity must not disable active-task deduplication'
   );
   assert.equal(identity.essayQuestionSetBusinessKey({ ...context, questionSetId: firstId }), firstId);
+  assert.throws(() => identity.essayQuestionSetBusinessKey(context), /questionSetId/);
+  assert.notEqual(
+    scope,
+    identity.essayQuestionSetGenerationScope({ ...context, purpose: 'mock' }),
+    'practice and mock generation must never share an active-task scope'
+  );
 
   const actionParams = tasks.generationTaskActionParams({
     intent: 'mock',
-    payload: { subject: '申论', questionSetId: firstId, entryMode: 'tutor', essayTopic: '归纳概括', date: '2026-08-12' }
+    payload: {
+      subject: '申论',
+      questionSetId: firstId,
+      entryMode: 'tutor',
+      essayTopic: '归纳概括',
+      essayType: 'long',
+      purpose: 'practice',
+      date: '2026-08-12'
+    }
   });
   assert.equal(actionParams.entryMode, 'tutor');
   assert.equal(actionParams.questionSetId, firstId);
+  assert.equal(actionParams.type, 'long');
+  assert.equal(actionParams.purpose, 'practice');
   assert.equal('mode' in actionParams, false, 'essay task navigation must use entryMode consistently');
 
   const legacyParams = tasks.generationTaskActionParams({
@@ -73,11 +89,13 @@ function verifyNavigation(navigation) {
     mode: 'tutor',
     date: '2026-08-12',
     topic: '归纳概括',
-    type: 'long'
+    type: 'long',
+    purpose: 'practice'
   });
   assert.equal(target.questionSetId, 'EssayQuestionSetId:1');
   assert.equal(target.entryMode, 'tutor', 'old task links remain readable while new links use entryMode');
   assert.equal(target.type, 'long');
+  assert.equal(target.purpose, 'practice');
   assert.deepEqual(navigation.essayHistoryLocation({ date: '2026-08-12', title: '申论' }), navigation.essayCenterLocation('self'));
   assert.equal(navigation.essayHistoryLocation({
     questionSetId: 'EssayQuestionSetId:2',
@@ -89,13 +107,14 @@ function verifyNavigation(navigation) {
   }).query.questionSetId, 'EssayQuestionSetId:2');
 }
 
-async function verifyClassificationAndOrdering({ EssayPracticeCenterFeature }) {
+async function verifyClassificationAndOrdering({ EssayPracticeCenterFeature }, { isEssayMockContext }) {
   const assets = [
     asset('EssayQuestionSetId:tutor-1', 'tutor', '私教题一', 100),
     asset('EssayQuestionSetId:self-2', 'self', '自主题二', 400),
     asset('EssayQuestionSetId:self-1', 'self', '自主题一', 300),
     asset('EssayQuestionSetId:true-1', 'true', '真题一', 200),
-    asset('EssayQuestionSetId:tutor-1', 'tutor', '私教题旧版本', 50)
+    asset('EssayQuestionSetId:tutor-1', 'tutor', '私教题旧版本', 50),
+    asset('EssayQuestionSetId:mock-1', 'self', '申论模考', 500, 'mock')
   ];
   const runtime = runtimeWithAssets(assets);
   const sets = await new EssayPracticeCenterFeature(runtime).listSets();
@@ -110,6 +129,8 @@ async function verifyClassificationAndOrdering({ EssayPracticeCenterFeature }) {
   assert.equal(sets.filter((item) => item.context.entryMode === 'self').length, 2);
   assert.equal(sets.filter((item) => item.context.entryMode === 'true').length, 1);
   assert(sets.every((item) => item.context.questionSetId === item.key));
+  assert.equal(isEssayMockContext(assets.at(-1).payload.essayContext), true);
+  assert.equal(isEssayMockContext(assets[0].payload.essayContext), false);
 }
 
 async function verifyHistorySummaryQuery({ EssayRepository }) {
@@ -122,6 +143,7 @@ async function verifyHistorySummaryQuery({ EssayRepository }) {
   const repository = new EssayRepository(async () => runtime);
   const history = await repository.listStates();
   assert.deepEqual(history.map((item) => item.key), ['EssayQuestionSetId:2', 'EssayQuestionSetId:1']);
+  assert(history.every((item) => 'question' in item && 'updatedAt' in item && !('state' in item)));
   assert.deepEqual(counters, { cycle: 1, list: 1, findLatest: 0 }, 'history summaries must not load every set detail');
 }
 
@@ -146,7 +168,7 @@ function runtimeWithAssets(assets, counters = { cycle: 0, list: 0, findLatest: 0
   };
 }
 
-function asset(businessKey, entryMode, title, updatedAt) {
+function asset(businessKey, entryMode, title, updatedAt, purpose = entryMode === 'true' ? 'true_question' : 'practice') {
   return {
     id: `asset:${businessKey}:${updatedAt}`,
     examCycleId: 'ExamCycleId:test',
@@ -155,7 +177,7 @@ function asset(businessKey, entryMode, title, updatedAt) {
     title,
     status: 'ready',
     payload: {
-      essayContext: { date: '2026-08-12', topic: '归纳概括', type: 'short', entryMode },
+      essayContext: { date: '2026-08-12', topic: '归纳概括', type: 'short', entryMode, purpose },
       question: { id: `question:${title}`, title, material: '材料', requirement: '要求' }
     },
     version: 1,

--- a/scripts/verify-essay-question-set-classification.mjs
+++ b/scripts/verify-essay-question-set-classification.mjs
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createServer } from '../web/node_modules/vite/dist/node/index.js';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../web');
+const server = await createServer({
+  root,
+  configFile: false,
+  resolve: { alias: { '@': path.join(root, 'src') } },
+  server: { middlewareMode: true, hmr: false, ws: false },
+  appType: 'custom'
+});
+
+try {
+  const [identity, navigation, tasks, featureModule, repositoryModule] = await Promise.all([
+    server.ssrLoadModule('/src/domain/essayQuestionSet.ts'),
+    server.ssrLoadModule('/src/features/practice/EssayNavigation.ts'),
+    server.ssrLoadModule('/src/services/GenerationTaskContract.ts'),
+    server.ssrLoadModule('/src/features/practice/EssayPracticeCenterFeature.ts'),
+    server.ssrLoadModule('/src/services/EssayRepository.ts')
+  ]);
+
+  verifyIdentityAndTaskScope(identity, tasks);
+  verifyNavigation(navigation);
+  await verifyClassificationAndOrdering(featureModule);
+  await verifyHistorySummaryQuery(repositoryModule);
+
+  console.log('Essay question-set classification verification passed.');
+} finally {
+  await server.close();
+}
+
+function verifyIdentityAndTaskScope(identity, tasks) {
+  const firstId = identity.createEssayQuestionSetId();
+  const secondId = identity.createEssayQuestionSetId();
+  assert.notEqual(firstId, secondId);
+
+  const context = { date: '2026-08-12', topic: '归纳概括', type: 'short', entryMode: 'tutor' };
+  const scope = identity.essayQuestionSetGenerationScope(context);
+  assert.equal(
+    tasks.generationTaskScope('project-1', { intent: 'mock', sourceId: firstId, scopeId: scope }),
+    tasks.generationTaskScope('project-1', { intent: 'mock', sourceId: secondId, scopeId: scope }),
+    'output identity must not disable active-task deduplication'
+  );
+  assert.equal(identity.essayQuestionSetBusinessKey({ ...context, questionSetId: firstId }), firstId);
+
+  const actionParams = tasks.generationTaskActionParams({
+    intent: 'mock',
+    payload: { subject: '申论', questionSetId: firstId, entryMode: 'tutor', essayTopic: '归纳概括', date: '2026-08-12' }
+  });
+  assert.equal(actionParams.entryMode, 'tutor');
+  assert.equal(actionParams.questionSetId, firstId);
+  assert.equal('mode' in actionParams, false, 'essay task navigation must use entryMode consistently');
+
+  const legacyParams = tasks.generationTaskActionParams({
+    intent: 'essayGrade',
+    payload: { entryMode: 'self', essayTopic: '归纳概括', essayDate: '2026-08-12' }
+  });
+  assert.equal('questionSetId' in legacyParams, false, 'missing ids must be omitted instead of serialized as empty query values');
+}
+
+function verifyNavigation(navigation) {
+  assert.deepEqual(navigation.essayCenterLocation('true'), {
+    path: '/vue/practice',
+    query: { subject: 'essay', mode: 'true' }
+  });
+  assert.equal(navigation.essayQuestionSetTargetFromQuery({ entryMode: 'tutor' }), undefined);
+  assert.throws(() => navigation.essayQuestionSetLocation({ questionSetId: '', date: '2026-08-12', topic: '归纳概括', type: 'short' }));
+
+  const target = navigation.essayQuestionSetTargetFromQuery({
+    questionSetId: 'EssayQuestionSetId:1',
+    mode: 'tutor',
+    date: '2026-08-12',
+    topic: '归纳概括',
+    type: 'long'
+  });
+  assert.equal(target.questionSetId, 'EssayQuestionSetId:1');
+  assert.equal(target.entryMode, 'tutor', 'old task links remain readable while new links use entryMode');
+  assert.equal(target.type, 'long');
+  assert.deepEqual(navigation.essayHistoryLocation({ date: '2026-08-12', title: '申论' }), navigation.essayCenterLocation('self'));
+  assert.equal(navigation.essayHistoryLocation({
+    questionSetId: 'EssayQuestionSetId:2',
+    essayEntryMode: 'true',
+    date: '2026-08-12',
+    essayTopic: '申发论述',
+    essayType: 'long',
+    title: '真题'
+  }).query.questionSetId, 'EssayQuestionSetId:2');
+}
+
+async function verifyClassificationAndOrdering({ EssayPracticeCenterFeature }) {
+  const assets = [
+    asset('EssayQuestionSetId:tutor-1', 'tutor', '私教题一', 100),
+    asset('EssayQuestionSetId:self-2', 'self', '自主题二', 400),
+    asset('EssayQuestionSetId:self-1', 'self', '自主题一', 300),
+    asset('EssayQuestionSetId:true-1', 'true', '真题一', 200),
+    asset('EssayQuestionSetId:tutor-1', 'tutor', '私教题旧版本', 50)
+  ];
+  const runtime = runtimeWithAssets(assets);
+  const sets = await new EssayPracticeCenterFeature(runtime).listSets();
+  assert.equal(sets.length, 4);
+  assert.deepEqual(sets.map((item) => item.key), [
+    'EssayQuestionSetId:self-2',
+    'EssayQuestionSetId:self-1',
+    'EssayQuestionSetId:true-1',
+    'EssayQuestionSetId:tutor-1'
+  ]);
+  assert.equal(sets.filter((item) => item.context.entryMode === 'tutor').length, 1);
+  assert.equal(sets.filter((item) => item.context.entryMode === 'self').length, 2);
+  assert.equal(sets.filter((item) => item.context.entryMode === 'true').length, 1);
+  assert(sets.every((item) => item.context.questionSetId === item.key));
+}
+
+async function verifyHistorySummaryQuery({ EssayRepository }) {
+  const counters = { cycle: 0, list: 0, findLatest: 0 };
+  const assets = [
+    asset('EssayQuestionSetId:2', 'self', '新题', 200),
+    asset('EssayQuestionSetId:1', 'tutor', '旧题', 100)
+  ];
+  const runtime = runtimeWithAssets(assets, counters);
+  const repository = new EssayRepository(async () => runtime);
+  const history = await repository.listStates();
+  assert.deepEqual(history.map((item) => item.key), ['EssayQuestionSetId:2', 'EssayQuestionSetId:1']);
+  assert.deepEqual(counters, { cycle: 1, list: 1, findLatest: 0 }, 'history summaries must not load every set detail');
+}
+
+function runtimeWithAssets(assets, counters = { cycle: 0, list: 0, findLatest: 0 }) {
+  return {
+    candidateRepository: {
+      findCurrentCycle: async () => {
+        counters.cycle += 1;
+        return { examCycle: { id: 'ExamCycleId:test' } };
+      }
+    },
+    learningAssetStore: {
+      list: async () => {
+        counters.list += 1;
+        return assets;
+      },
+      findLatest: async () => {
+        counters.findLatest += 1;
+        return undefined;
+      }
+    }
+  };
+}
+
+function asset(businessKey, entryMode, title, updatedAt) {
+  return {
+    id: `asset:${businessKey}:${updatedAt}`,
+    examCycleId: 'ExamCycleId:test',
+    kind: 'essay_question',
+    businessKey,
+    title,
+    status: 'ready',
+    payload: {
+      essayContext: { date: '2026-08-12', topic: '归纳概括', type: 'short', entryMode },
+      question: { id: `question:${title}`, title, material: '材料', requirement: '要求' }
+    },
+    version: 1,
+    createdAt: updatedAt,
+    updatedAt
+  };
+}

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,7 @@
     "check:true-question-practice": "node ../scripts/verify-true-question-practice.mjs",
     "check:true-question-reference-pack": "node ../scripts/verify-true-question-reference-pack.mjs",
     "check:study-lecture-library": "node ../scripts/verify-study-lecture-library.mjs",
+    "check:essay-question-sets": "node ../scripts/verify-essay-question-set-classification.mjs",
     "check:proactive-tutor-loop": "node ../scripts/verify-proactive-tutor-loop.mjs",
     "check:learning-evidence": "node ../scripts/verify-learning-evidence.mjs",
     "check:learning-reliability": "node ../scripts/verify-learning-reliability.mjs",
@@ -37,7 +38,7 @@
     "check:mastery-policy": "node ../scripts/verify-mastery-policy.mjs",
     "check:ability-calibration": "node ../scripts/verify-ability-calibration.mjs",
     "typecheck": "vue-tsc",
-    "build": "npm run check:code-quality && npm run check:release-security && npm run check:architecture && npm run check:sqlite-migrations && npm run check:data-maintenance && npm run check:metadata && npm run check:content-metadata && npm run check:content-schema && npm run check:content-quality-benchmark && npm run check:prompt-compiler && npm run check:provider-gateway && npm run check:web-research && npm run check:document-input && npm run check:generation-workflow && npm run check:generation-diversity && npm run check:generation-foundation && npm run check:content-enrichment && npm run check:question-source-foundation && npm run check:question-import-workflow && npm run check:true-question-practice && npm run check:true-question-reference-pack && npm run check:study-lecture-library && npm run check:proactive-tutor-loop && npm run check:learning-evidence && npm run check:learning-reliability && npm run check:ios-lifecycle-recovery && npm run check:agent-runtime && npm run check:agent-loop && npm run check:pi-agent-runtime && npm run check:chat-context && npm run check:mastery-policy && npm run check:ability-calibration && npm run typecheck && vite build",
+    "build": "npm run check:code-quality && npm run check:release-security && npm run check:architecture && npm run check:sqlite-migrations && npm run check:data-maintenance && npm run check:metadata && npm run check:content-metadata && npm run check:content-schema && npm run check:content-quality-benchmark && npm run check:prompt-compiler && npm run check:provider-gateway && npm run check:web-research && npm run check:document-input && npm run check:generation-workflow && npm run check:generation-diversity && npm run check:generation-foundation && npm run check:content-enrichment && npm run check:question-source-foundation && npm run check:question-import-workflow && npm run check:true-question-practice && npm run check:true-question-reference-pack && npm run check:study-lecture-library && npm run check:essay-question-sets && npm run check:proactive-tutor-loop && npm run check:learning-evidence && npm run check:learning-reliability && npm run check:ios-lifecycle-recovery && npm run check:agent-runtime && npm run check:agent-loop && npm run check:pi-agent-runtime && npm run check:chat-context && npm run check:mastery-policy && npm run check:ability-calibration && npm run typecheck && vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/composition-root/agent/BusinessAgentExecutors.ts
+++ b/web/src/composition-root/agent/BusinessAgentExecutors.ts
@@ -8,7 +8,11 @@ import { aiChatRepository } from '@/services/AIChatRepository';
 import { buildDailyDigestRequest } from '@/services/DailyDigestGenerationPolicy';
 import { webResearchService } from '@/services/WebResearchService';
 import type { EssayQuestionRecord } from '@/services/EssayRepository';
-import { essayQuestionSetBusinessKey, normalizeEssayQuestionSetMode } from '@/domain/essayQuestionSet';
+import {
+  essayQuestionSetBusinessKey,
+  normalizeEssayQuestionSetMode,
+  normalizeEssayQuestionSetPurpose
+} from '@/domain/essayQuestionSet';
 import type { AITextMessage } from '../ai/ConfiguredAIClient';
 import {
   GenerationVariationKind,
@@ -273,12 +277,16 @@ export const chatExecutor: BusinessAgentExecutor = async (task, context) => {
 export const essayGradeExecutor: BusinessAgentExecutor = async (task, context) => {
   const content = asString(task.payload?.content);
   if (!content.trim()) throw new Error('申论批改任务缺少作答内容');
+  const questionSetId = asString(task.payload?.questionSetId).trim();
+  if (!questionSetId) throw new Error('申论批改任务缺少题组标识');
+  const entryMode = normalizeEssayQuestionSetMode(task.payload?.entryMode);
   const essayContext = {
-    questionSetId: asString(task.payload?.questionSetId) || undefined,
+    questionSetId,
     date: asString(task.payload?.essayDate) || new Date().toISOString().slice(0, 10),
     topic: asString(task.payload?.essayTopic) || '申论',
     type: asString(task.payload?.essayType) === 'long' ? 'long' : 'short',
-    entryMode: normalizeEssayQuestionSetMode(task.payload?.entryMode)
+    entryMode,
+    purpose: normalizeEssayQuestionSetPurpose(task.payload?.purpose, entryMode)
   };
   const questionAsset = await context.findLatestLearningAsset({
     kind: LearningAssetKind.EssayQuestion,
@@ -509,6 +517,7 @@ export const mockExecutor: BusinessAgentExecutor = async (task, context) => {
     const date = asString(task.payload?.date) || new Date().toISOString().slice(0, 10);
     const questionSetId = asString(task.payload?.questionSetId) || `EssayQuestionSetId:${task.id}`;
     const entryMode = normalizeEssayQuestionSetMode(task.payload?.entryMode);
+    const purpose = normalizeEssayQuestionSetPurpose(task.payload?.purpose, entryMode);
     await context.update(20, '生成申论材料');
     const recentEssayAssets = await context.listLearningAssets({
       kinds: [LearningAssetKind.EssayQuestion],
@@ -532,18 +541,18 @@ export const mockExecutor: BusinessAgentExecutor = async (task, context) => {
     const question = await parseOrRepairEssayQuestion(text, context);
     const saved = await context.saveLearningAsset({
       kind: LearningAssetKind.EssayQuestion,
-      businessKey: essayQuestionSetBusinessKey({ questionSetId, date, topic: essayTopic, type: essayType, entryMode }),
+      businessKey: essayQuestionSetBusinessKey({ questionSetId, date, topic: essayTopic, type: essayType, entryMode, purpose }),
       title: question.title,
       payload: {
         question,
-        essayContext: { questionSetId, date, topic: essayTopic, type: essayType, entryMode }
+        essayContext: { questionSetId, date, topic: essayTopic, type: essayType, entryMode, purpose }
       }
     });
     await context.setResult({
       resultRef: saved.id,
       payload: {
         assetId: saved.id,
-        essayContext: { questionSetId, date, topic: essayTopic, type: essayType, entryMode }
+        essayContext: { questionSetId, date, topic: essayTopic, type: essayType, entryMode, purpose }
       }
     });
     await context.update(94, '申论模考题已写入');

--- a/web/src/composition-root/agent/BusinessAgentExecutors.ts
+++ b/web/src/composition-root/agent/BusinessAgentExecutors.ts
@@ -8,6 +8,7 @@ import { aiChatRepository } from '@/services/AIChatRepository';
 import { buildDailyDigestRequest } from '@/services/DailyDigestGenerationPolicy';
 import { webResearchService } from '@/services/WebResearchService';
 import type { EssayQuestionRecord } from '@/services/EssayRepository';
+import { essayQuestionSetBusinessKey, normalizeEssayQuestionSetMode } from '@/domain/essayQuestionSet';
 import type { AITextMessage } from '../ai/ConfiguredAIClient';
 import {
   GenerationVariationKind,
@@ -33,10 +34,6 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
     : {};
-}
-
-function essayBusinessKey(input: { date: string; topic: string; type: string }): string {
-  return `essay:${input.date}:${input.topic}:${input.type}`;
 }
 
 function digestBusinessKey(tab: DigestTab, date: string): string {
@@ -277,13 +274,15 @@ export const essayGradeExecutor: BusinessAgentExecutor = async (task, context) =
   const content = asString(task.payload?.content);
   if (!content.trim()) throw new Error('申论批改任务缺少作答内容');
   const essayContext = {
+    questionSetId: asString(task.payload?.questionSetId) || undefined,
     date: asString(task.payload?.essayDate) || new Date().toISOString().slice(0, 10),
     topic: asString(task.payload?.essayTopic) || '申论',
-    type: asString(task.payload?.essayType) === 'long' ? 'long' : 'short'
+    type: asString(task.payload?.essayType) === 'long' ? 'long' : 'short',
+    entryMode: normalizeEssayQuestionSetMode(task.payload?.entryMode)
   };
   const questionAsset = await context.findLatestLearningAsset({
     kind: LearningAssetKind.EssayQuestion,
-    businessKey: essayBusinessKey(essayContext)
+    businessKey: essayQuestionSetBusinessKey(essayContext)
   });
   if (!questionAsset) throw new Error('当前申论题目不存在，请先生成题目后再批改');
   const question = asRecord(questionAsset.payload.question);
@@ -305,7 +304,7 @@ export const essayGradeExecutor: BusinessAgentExecutor = async (task, context) =
   const parsed = parseEssayFeedback(rawFeedback);
   const saved = await context.saveLearningAsset({
     kind: LearningAssetKind.EssayAttempt,
-    businessKey: essayBusinessKey(essayContext),
+    businessKey: essayQuestionSetBusinessKey(essayContext),
     title: `${essayContext.topic}批改 · ${essayContext.date}`,
     payload: {
       questionAssetId: questionAsset.id,
@@ -508,9 +507,8 @@ export const mockExecutor: BusinessAgentExecutor = async (task, context) => {
     const essayType = asString(task.payload?.essayType) === 'long' ? 'long' : 'short';
     const essayQuestionCount = Math.max(1, Math.min(3, Number(task.payload?.essayQuestionCount || 1)));
     const date = asString(task.payload?.date) || new Date().toISOString().slice(0, 10);
-    const entryMode = asString(task.payload?.entryMode) === 'tutor' || asString(task.payload?.entryMode) === 'true'
-      ? asString(task.payload?.entryMode)
-      : 'self';
+    const questionSetId = asString(task.payload?.questionSetId) || `EssayQuestionSetId:${task.id}`;
+    const entryMode = normalizeEssayQuestionSetMode(task.payload?.entryMode);
     await context.update(20, '生成申论材料');
     const recentEssayAssets = await context.listLearningAssets({
       kinds: [LearningAssetKind.EssayQuestion],
@@ -534,18 +532,18 @@ export const mockExecutor: BusinessAgentExecutor = async (task, context) => {
     const question = await parseOrRepairEssayQuestion(text, context);
     const saved = await context.saveLearningAsset({
       kind: LearningAssetKind.EssayQuestion,
-      businessKey: essayBusinessKey({ date, topic: essayTopic, type: essayType }),
+      businessKey: essayQuestionSetBusinessKey({ questionSetId, date, topic: essayTopic, type: essayType, entryMode }),
       title: question.title,
       payload: {
         question,
-        essayContext: { date, topic: essayTopic, type: essayType, entryMode }
+        essayContext: { questionSetId, date, topic: essayTopic, type: essayType, entryMode }
       }
     });
     await context.setResult({
       resultRef: saved.id,
       payload: {
         assetId: saved.id,
-        essayContext: { date, topic: essayTopic, type: essayType, entryMode }
+        essayContext: { questionSetId, date, topic: essayTopic, type: essayType, entryMode }
       }
     });
     await context.update(94, '申论模考题已写入');

--- a/web/src/composition-root/essay/EssayGenerationCoordinator.ts
+++ b/web/src/composition-root/essay/EssayGenerationCoordinator.ts
@@ -1,6 +1,10 @@
 import type { TutorDatabaseRuntime } from '../database/TutorDatabaseRuntime';
 import type { AgentRunView } from '@/modules/agent/public';
-import { essayFlowService, type EssayContext } from '@/services/EssayFlowService';
+import {
+  essayFlowService,
+  type EssayContext,
+  type EssayGenerationContext
+} from '@/services/EssayFlowService';
 
 /**
  * Composition-root adapter for the essay generation workflow.
@@ -9,7 +13,7 @@ import { essayFlowService, type EssayContext } from '@/services/EssayFlowService
 export class EssayGenerationCoordinator {
   constructor(private readonly runtime: TutorDatabaseRuntime) {}
 
-  async start(context: EssayContext, questionCount: number): Promise<AgentRunView> {
+  async start(context: EssayGenerationContext, questionCount: number): Promise<AgentRunView> {
     const result = await essayFlowService.enqueueQuestionGeneration(context, { questionCount });
     return result.task;
   }
@@ -20,6 +24,7 @@ export class EssayGenerationCoordinator {
       isEssayGenerationTask(task)
       && task.isActive
       && (!mode || (task.actionParams.entryMode || task.actionParams.mode) === mode)
+      && task.actionParams.purpose !== 'mock'
     ));
   }
 
@@ -41,4 +46,4 @@ function isEssayGenerationTask(task: AgentRunView): boolean {
   return task.intent === 'mock' && task.actionRoute === '/vue/essay';
 }
 
-export type { EssayContext };
+export type { EssayContext, EssayGenerationContext };

--- a/web/src/composition-root/essay/EssayGenerationCoordinator.ts
+++ b/web/src/composition-root/essay/EssayGenerationCoordinator.ts
@@ -16,7 +16,11 @@ export class EssayGenerationCoordinator {
 
   async findActive(mode?: EssayContext['entryMode']): Promise<AgentRunView | undefined> {
     const tasks = await this.runtime.getAgentRunViews.execute({ limit: 50 });
-    return tasks.find((task) => isEssayGenerationTask(task) && task.isActive && (!mode || task.actionParams.mode === mode));
+    return tasks.find((task) => (
+      isEssayGenerationTask(task)
+      && task.isActive
+      && (!mode || (task.actionParams.entryMode || task.actionParams.mode) === mode)
+    ));
   }
 
   async find(taskId: string): Promise<AgentRunView | undefined> {

--- a/web/src/composition-root/public.ts
+++ b/web/src/composition-root/public.ts
@@ -9,7 +9,11 @@ export { getTutorRuntime, initializeTutorRuntime } from './TutorRuntimeProvider'
 export { createConfiguredProviderGateway } from './ai/createConfiguredProviderGateway';
 export { agentWorkerCoordinator } from './agent/AgentWorkerCoordinator';
 export { enqueueBusinessAgentTask } from './agent/enqueueBusinessAgentTask';
-export { EssayGenerationCoordinator, type EssayContext } from './essay/EssayGenerationCoordinator';
+export {
+  EssayGenerationCoordinator,
+  type EssayContext,
+  type EssayGenerationContext
+} from './essay/EssayGenerationCoordinator';
 export {
   importAgentAttachment,
   importAgentAttachments,

--- a/web/src/domain/essayQuestionSet.ts
+++ b/web/src/domain/essayQuestionSet.ts
@@ -1,0 +1,34 @@
+export type EssayQuestionSetMode = 'tutor' | 'self' | 'true';
+
+export interface EssayQuestionSetIdentity {
+  readonly questionSetId?: string;
+  readonly date: string;
+  readonly topic: string;
+  readonly type: string;
+  readonly entryMode?: EssayQuestionSetMode;
+}
+
+export function createEssayQuestionSetId(): string {
+  return `EssayQuestionSetId:${crypto.randomUUID()}`;
+}
+
+export function essayQuestionSetGenerationScope(identity: EssayQuestionSetIdentity): string {
+  return [
+    'essay-generation',
+    normalizeEssayQuestionSetMode(identity.entryMode),
+    identity.date,
+    identity.topic,
+    identity.type
+  ].join(':');
+}
+
+export function essayQuestionSetBusinessKey(identity: EssayQuestionSetIdentity): string {
+  const questionSetId = identity.questionSetId?.trim();
+  if (questionSetId) return questionSetId;
+  const mode = identity.entryMode && identity.entryMode !== 'self' ? `:${identity.entryMode}` : '';
+  return `essay:${identity.date}:${identity.topic}:${identity.type}${mode}`;
+}
+
+export function normalizeEssayQuestionSetMode(value: unknown): EssayQuestionSetMode {
+  return value === 'tutor' || value === 'true' ? value : 'self';
+}

--- a/web/src/domain/essayQuestionSet.ts
+++ b/web/src/domain/essayQuestionSet.ts
@@ -1,4 +1,5 @@
 export type EssayQuestionSetMode = 'tutor' | 'self' | 'true';
+export type EssayQuestionSetPurpose = 'practice' | 'mock' | 'true_question';
 
 export interface EssayQuestionSetIdentity {
   readonly questionSetId?: string;
@@ -6,6 +7,7 @@ export interface EssayQuestionSetIdentity {
   readonly topic: string;
   readonly type: string;
   readonly entryMode?: EssayQuestionSetMode;
+  readonly purpose?: EssayQuestionSetPurpose;
 }
 
 export function createEssayQuestionSetId(): string {
@@ -15,6 +17,7 @@ export function createEssayQuestionSetId(): string {
 export function essayQuestionSetGenerationScope(identity: EssayQuestionSetIdentity): string {
   return [
     'essay-generation',
+    normalizeEssayQuestionSetPurpose(identity.purpose, identity.entryMode),
     normalizeEssayQuestionSetMode(identity.entryMode),
     identity.date,
     identity.topic,
@@ -25,10 +28,23 @@ export function essayQuestionSetGenerationScope(identity: EssayQuestionSetIdenti
 export function essayQuestionSetBusinessKey(identity: EssayQuestionSetIdentity): string {
   const questionSetId = identity.questionSetId?.trim();
   if (questionSetId) return questionSetId;
-  const mode = identity.entryMode && identity.entryMode !== 'self' ? `:${identity.entryMode}` : '';
-  return `essay:${identity.date}:${identity.topic}:${identity.type}${mode}`;
+  throw new TypeError('Essay question-set identity requires questionSetId');
 }
 
 export function normalizeEssayQuestionSetMode(value: unknown): EssayQuestionSetMode {
   return value === 'tutor' || value === 'true' ? value : 'self';
+}
+
+export function normalizeEssayQuestionSetPurpose(
+  value: unknown,
+  entryMode?: unknown
+): EssayQuestionSetPurpose {
+  if (value === 'mock' || value === 'true_question') return value;
+  return normalizeEssayQuestionSetMode(entryMode) === 'true' ? 'true_question' : 'practice';
+}
+
+export function isEssayMockContext(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const context = value as Record<string, unknown>;
+  return normalizeEssayQuestionSetPurpose(context.purpose, context.entryMode) === 'mock';
 }

--- a/web/src/features/practice/EssayNavigation.ts
+++ b/web/src/features/practice/EssayNavigation.ts
@@ -1,0 +1,74 @@
+import type { RouteLocationRaw } from 'vue-router';
+import { normalizeEssayQuestionSetMode, type EssayQuestionSetMode } from '@/domain/essayQuestionSet';
+
+export interface EssayQuestionSetRouteTarget {
+  readonly questionSetId: string;
+  readonly entryMode?: EssayQuestionSetMode;
+  readonly date: string;
+  readonly topic: string;
+  readonly type: 'short' | 'long';
+}
+
+export interface EssayHistoryRouteTarget {
+  readonly questionSetId?: string;
+  readonly essayEntryMode?: EssayQuestionSetMode;
+  readonly date: string;
+  readonly essayTopic?: string;
+  readonly title: string;
+  readonly essayType?: 'short' | 'long';
+}
+
+export function essayCenterLocation(entryMode: EssayQuestionSetMode = 'tutor'): RouteLocationRaw {
+  return {
+    path: '/vue/practice',
+    query: { subject: 'essay', mode: normalizeEssayQuestionSetMode(entryMode) }
+  };
+}
+
+export function essayQuestionSetLocation(target: EssayQuestionSetRouteTarget): RouteLocationRaw {
+  const questionSetId = target.questionSetId.trim();
+  if (!questionSetId) throw new TypeError('Essay question-set navigation requires questionSetId');
+  return {
+    path: '/vue/essay',
+    query: {
+      questionSetId,
+      entryMode: normalizeEssayQuestionSetMode(target.entryMode),
+      date: target.date,
+      topic: target.topic,
+      type: target.type
+    }
+  };
+}
+
+export function essayHistoryLocation(target: EssayHistoryRouteTarget): RouteLocationRaw {
+  if (!target.questionSetId?.trim()) return essayCenterLocation('self');
+  return essayQuestionSetLocation({
+    questionSetId: target.questionSetId,
+    entryMode: target.essayEntryMode,
+    date: target.date,
+    topic: target.essayTopic || target.title,
+    type: target.essayType || 'short'
+  });
+}
+
+export function essayQuestionSetTargetFromQuery(query: Readonly<Record<string, unknown>>): EssayQuestionSetRouteTarget | undefined {
+  const questionSetId = text(query.questionSetId);
+  if (!questionSetId) return undefined;
+  const topic = text(query.topic) || '申论';
+  return {
+    questionSetId,
+    entryMode: normalizeEssayQuestionSetMode(text(query.entryMode) || text(query.mode)),
+    date: text(query.date) || localDate(),
+    topic,
+    type: text(query.type) === 'long' ? 'long' : 'short'
+  };
+}
+
+function text(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function localDate(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+}

--- a/web/src/features/practice/EssayNavigation.ts
+++ b/web/src/features/practice/EssayNavigation.ts
@@ -1,5 +1,10 @@
 import type { RouteLocationRaw } from 'vue-router';
-import { normalizeEssayQuestionSetMode, type EssayQuestionSetMode } from '@/domain/essayQuestionSet';
+import {
+  normalizeEssayQuestionSetMode,
+  normalizeEssayQuestionSetPurpose,
+  type EssayQuestionSetMode,
+  type EssayQuestionSetPurpose
+} from '@/domain/essayQuestionSet';
 
 export interface EssayQuestionSetRouteTarget {
   readonly questionSetId: string;
@@ -7,6 +12,7 @@ export interface EssayQuestionSetRouteTarget {
   readonly date: string;
   readonly topic: string;
   readonly type: 'short' | 'long';
+  readonly purpose?: EssayQuestionSetPurpose;
 }
 
 export interface EssayHistoryRouteTarget {
@@ -16,6 +22,7 @@ export interface EssayHistoryRouteTarget {
   readonly essayTopic?: string;
   readonly title: string;
   readonly essayType?: 'short' | 'long';
+  readonly essayPurpose?: EssayQuestionSetPurpose;
 }
 
 export function essayCenterLocation(entryMode: EssayQuestionSetMode = 'tutor'): RouteLocationRaw {
@@ -35,7 +42,8 @@ export function essayQuestionSetLocation(target: EssayQuestionSetRouteTarget): R
       entryMode: normalizeEssayQuestionSetMode(target.entryMode),
       date: target.date,
       topic: target.topic,
-      type: target.type
+      type: target.type,
+      purpose: normalizeEssayQuestionSetPurpose(target.purpose, target.entryMode)
     }
   };
 }
@@ -47,7 +55,8 @@ export function essayHistoryLocation(target: EssayHistoryRouteTarget): RouteLoca
     entryMode: target.essayEntryMode,
     date: target.date,
     topic: target.essayTopic || target.title,
-    type: target.essayType || 'short'
+    type: target.essayType || 'short',
+    purpose: target.essayPurpose
   });
 }
 
@@ -60,7 +69,8 @@ export function essayQuestionSetTargetFromQuery(query: Readonly<Record<string, u
     entryMode: normalizeEssayQuestionSetMode(text(query.entryMode) || text(query.mode)),
     date: text(query.date) || localDate(),
     topic,
-    type: text(query.type) === 'long' ? 'long' : 'short'
+    type: text(query.type) === 'long' ? 'long' : 'short',
+    purpose: normalizeEssayQuestionSetPurpose(text(query.purpose), text(query.entryMode) || text(query.mode))
   };
 }
 

--- a/web/src/features/practice/EssayPracticeCenterFeature.ts
+++ b/web/src/features/practice/EssayPracticeCenterFeature.ts
@@ -4,10 +4,12 @@ import {
   LearningAssetStatus,
   type LearningAssetRecord
 } from '@/modules/content/public';
+import { normalizeEssayQuestionSetMode } from '@/domain/essayQuestionSet';
 
 export type EssayPracticeMode = 'tutor' | 'self' | 'true';
 
 export interface EssayPracticeContext {
+  readonly questionSetId?: string;
   readonly date: string;
   readonly topic: string;
   readonly type: 'short' | 'long';
@@ -16,6 +18,7 @@ export interface EssayPracticeContext {
 
 export interface EssayPracticeSet {
   readonly key: string;
+  readonly updatedAt: number;
   readonly context: EssayPracticeContext;
   readonly question?: { readonly id: string; readonly title: string };
 }
@@ -30,10 +33,11 @@ function contextFromAsset(asset: LearningAssetRecord): EssayPracticeContext {
     ? raw as Record<string, unknown>
     : {};
   return {
+    questionSetId: asset.businessKey,
     date: typeof record.date === 'string' ? record.date : today(),
     topic: typeof record.topic === 'string' ? record.topic : '申论',
     type: record.type === 'long' ? 'long' : 'short',
-    entryMode: record.entryMode === 'tutor' || record.entryMode === 'true' ? record.entryMode : 'self'
+    entryMode: normalizeEssayQuestionSetMode(record.entryMode)
   };
 }
 
@@ -62,7 +66,12 @@ export class EssayPracticeCenterFeature {
     const latest = new Map<string, LearningAssetRecord>();
     for (const asset of assets) if (!latest.has(asset.businessKey)) latest.set(asset.businessKey, asset);
     return [...latest.values()]
-      .map((asset) => ({ key: asset.businessKey, context: contextFromAsset(asset), question: questionFromAsset(asset) }))
-      .sort((left, right) => right.context.date.localeCompare(left.context.date) || right.key.localeCompare(left.key));
+      .map((asset) => ({
+        key: asset.businessKey,
+        updatedAt: asset.updatedAt,
+        context: contextFromAsset(asset),
+        question: questionFromAsset(asset)
+      }))
+      .sort((left, right) => right.updatedAt - left.updatedAt || right.key.localeCompare(left.key));
   }
 }

--- a/web/src/features/practice/EssayPracticeCenterFeature.ts
+++ b/web/src/features/practice/EssayPracticeCenterFeature.ts
@@ -4,7 +4,11 @@ import {
   LearningAssetStatus,
   type LearningAssetRecord
 } from '@/modules/content/public';
-import { normalizeEssayQuestionSetMode } from '@/domain/essayQuestionSet';
+import {
+  normalizeEssayQuestionSetMode,
+  normalizeEssayQuestionSetPurpose,
+  type EssayQuestionSetPurpose
+} from '@/domain/essayQuestionSet';
 
 export type EssayPracticeMode = 'tutor' | 'self' | 'true';
 
@@ -14,6 +18,7 @@ export interface EssayPracticeContext {
   readonly topic: string;
   readonly type: 'short' | 'long';
   readonly entryMode?: EssayPracticeMode;
+  readonly purpose?: EssayQuestionSetPurpose;
 }
 
 export interface EssayPracticeSet {
@@ -37,7 +42,8 @@ function contextFromAsset(asset: LearningAssetRecord): EssayPracticeContext {
     date: typeof record.date === 'string' ? record.date : today(),
     topic: typeof record.topic === 'string' ? record.topic : '申论',
     type: record.type === 'long' ? 'long' : 'short',
-    entryMode: normalizeEssayQuestionSetMode(record.entryMode)
+    entryMode: normalizeEssayQuestionSetMode(record.entryMode),
+    purpose: normalizeEssayQuestionSetPurpose(record.purpose, record.entryMode)
   };
 }
 
@@ -66,6 +72,7 @@ export class EssayPracticeCenterFeature {
     const latest = new Map<string, LearningAssetRecord>();
     for (const asset of assets) if (!latest.has(asset.businessKey)) latest.set(asset.businessKey, asset);
     return [...latest.values()]
+      .filter((asset) => contextFromAsset(asset).purpose !== 'mock')
       .map((asset) => ({
         key: asset.businessKey,
         updatedAt: asset.updatedAt,

--- a/web/src/features/practice/EssayPracticeCenterPanel.vue
+++ b/web/src/features/practice/EssayPracticeCenterPanel.vue
@@ -110,6 +110,7 @@ import AiTaskPendingState from '@/components/AiTaskPendingState.vue';
 import type { AgentRunView } from '@/modules/agent/public';
 import { EssayGenerationCoordinator, initializeTutorRuntime, type EssayContext } from '@/composition-root/public';
 import { EssayPracticeCenterFeature, type EssayPracticeMode, type EssayPracticeSet } from './EssayPracticeCenterFeature';
+import { essayQuestionSetLocation } from './EssayNavigation';
 
 type Mode = EssayPracticeMode;
 const props = defineProps<{ modelValue: Mode }>();
@@ -185,14 +186,9 @@ async function openPractice() {
     await startGeneration({ entryMode: 'tutor', topic: '归纳概括', count: 1 });
     return;
   }
-  opening.value = true;
-  try {
-    const query = {
-      source: 'practice-center',
-      entryMode: props.modelValue,
-    };
-    await router.push({ path: '/vue/essay', query });
-  } finally { opening.value = false; }
+  const latestTrueSet = sets.value[0];
+  if (latestTrueSet) await openSet(latestTrueSet);
+  else error.value = '当前还没有可练习的申论真题。请先完成申论真题导入。';
 }
 
 async function submitCustom() {
@@ -218,6 +214,7 @@ async function startGeneration(input: { entryMode: Mode; topic: string; count: n
   pendingQuestionCount.value = input.count;
   try {
     activeTask.value = await coordinator.value.start(context, input.count);
+    pendingContext.value = contextFromTask(activeTask.value) || context;
   } catch (cause) {
     error.value = cause instanceof Error ? cause.message : '申论生成失败';
   } finally {
@@ -273,10 +270,20 @@ async function retryGeneration() {
 function openHistory() { showHistory.value = true; }
 async function openSet(item: EssayPracticeSet) {
   showHistory.value = false;
-  await router.push({ path: '/vue/essay', query: { source: 'practice-center', entryMode: normalizedMode(item.context.entryMode), date: item.context.date, topic: item.context.topic } });
+  await router.push(essayQuestionSetLocation({
+    questionSetId: item.context.questionSetId || item.key,
+    entryMode: normalizedMode(item.context.entryMode),
+    date: item.context.date,
+    topic: item.context.topic,
+    type: item.context.type
+  }));
 }
 async function openLatestSet(context: EssayContext) {
-  const item = allStates.value.find((candidate) => candidate.context.date === context.date && candidate.context.topic === context.topic && normalizedMode(candidate.context.entryMode) === context.entryMode);
+  const item = allStates.value.find((candidate) => (
+    context.questionSetId
+      ? candidate.context.questionSetId === context.questionSetId
+      : candidate.context.date === context.date && candidate.context.topic === context.topic && normalizedMode(candidate.context.entryMode) === context.entryMode
+  ));
   if (item) {
     await openSet(item);
   } else {
@@ -284,11 +291,12 @@ async function openLatestSet(context: EssayContext) {
   }
 }
 function contextFromTask(task: AgentRunView): EssayContext | undefined {
-  const mode = task.actionParams.mode;
+  const mode = task.actionParams.entryMode || task.actionParams.mode;
   const topic = task.actionParams.topic;
   const date = task.actionParams.date;
+  const questionSetId = task.actionParams.questionSetId;
   if ((mode !== 'tutor' && mode !== 'self' && mode !== 'true') || typeof topic !== 'string' || typeof date !== 'string') return undefined;
-  return { entryMode: mode, topic, date, type: topic === '申发论述' ? 'long' : 'short' };
+  return { questionSetId: typeof questionSetId === 'string' && questionSetId ? questionSetId : undefined, entryMode: mode, topic, date, type: topic === '申发论述' ? 'long' : 'short' };
 }
 function normalizedMode(value?: EssayPracticeMode): Mode { return value === 'tutor' || value === 'true' ? value : 'self'; }
 function modeLabelFor(value?: EssayPracticeMode): string { return modes.find((item) => item.value === normalizedMode(value))?.label || '自主刷题'; }

--- a/web/src/features/practice/EssayPracticeCenterPanel.vue
+++ b/web/src/features/practice/EssayPracticeCenterPanel.vue
@@ -108,7 +108,12 @@ import BottomSheet from '@/components/layout/BottomSheet.vue';
 import { AppStateView, InitialRefreshState } from '@/capabilities/design-system/public';
 import AiTaskPendingState from '@/components/AiTaskPendingState.vue';
 import type { AgentRunView } from '@/modules/agent/public';
-import { EssayGenerationCoordinator, initializeTutorRuntime, type EssayContext } from '@/composition-root/public';
+import {
+  EssayGenerationCoordinator,
+  initializeTutorRuntime,
+  type EssayContext,
+  type EssayGenerationContext
+} from '@/composition-root/public';
 import { EssayPracticeCenterFeature, type EssayPracticeMode, type EssayPracticeSet } from './EssayPracticeCenterFeature';
 import { essayQuestionSetLocation } from './EssayNavigation';
 
@@ -121,7 +126,7 @@ const coordinator = ref<EssayGenerationCoordinator>();
 const loading = ref(true);
 const opening = ref(false);
 const activeTask = ref<AgentRunView>();
-const pendingContext = ref<EssayContext>();
+const pendingContext = ref<EssayGenerationContext>();
 const pendingQuestionCount = ref(1);
 const error = ref('');
 const showHistory = ref(false);
@@ -204,8 +209,9 @@ async function startGeneration(input: { entryMode: Mode; topic: string; count: n
   if (!coordinator.value || activeTask.value?.isActive) return;
   opening.value = true;
   error.value = '';
-  const context: EssayContext = {
+  const context: EssayGenerationContext = {
     entryMode: input.entryMode,
+    purpose: input.entryMode === 'true' ? 'true_question' : 'practice',
     topic: input.topic,
     type: input.topic === '申发论述' ? 'long' : 'short',
     date: new Date().toISOString().slice(0, 10)
@@ -275,10 +281,11 @@ async function openSet(item: EssayPracticeSet) {
     entryMode: normalizedMode(item.context.entryMode),
     date: item.context.date,
     topic: item.context.topic,
-    type: item.context.type
+    type: item.context.type,
+    purpose: item.context.purpose
   }));
 }
-async function openLatestSet(context: EssayContext) {
+async function openLatestSet(context: EssayGenerationContext) {
   const item = allStates.value.find((candidate) => (
     context.questionSetId
       ? candidate.context.questionSetId === context.questionSetId
@@ -295,8 +302,23 @@ function contextFromTask(task: AgentRunView): EssayContext | undefined {
   const topic = task.actionParams.topic;
   const date = task.actionParams.date;
   const questionSetId = task.actionParams.questionSetId;
-  if ((mode !== 'tutor' && mode !== 'self' && mode !== 'true') || typeof topic !== 'string' || typeof date !== 'string') return undefined;
-  return { questionSetId: typeof questionSetId === 'string' && questionSetId ? questionSetId : undefined, entryMode: mode, topic, date, type: topic === '申发论述' ? 'long' : 'short' };
+  const type = task.actionParams.type;
+  const purpose = task.actionParams.purpose;
+  if (
+    (mode !== 'tutor' && mode !== 'self' && mode !== 'true')
+    || typeof topic !== 'string'
+    || typeof date !== 'string'
+    || typeof questionSetId !== 'string'
+    || !questionSetId
+  ) return undefined;
+  return {
+    questionSetId,
+    entryMode: mode,
+    topic,
+    date,
+    type: type === 'long' ? 'long' : 'short',
+    purpose: purpose === 'mock' || purpose === 'true_question' ? purpose : 'practice'
+  };
 }
 function normalizedMode(value?: EssayPracticeMode): Mode { return value === 'tutor' || value === 'true' ? value : 'self'; }
 function modeLabelFor(value?: EssayPracticeMode): string { return modes.find((item) => item.value === normalizedMode(value))?.label || '自主刷题'; }

--- a/web/src/modules/content/adapters/IndexedDbLearningAssetRepository.ts
+++ b/web/src/modules/content/adapters/IndexedDbLearningAssetRepository.ts
@@ -55,13 +55,15 @@ export class IndexedDbLearningAssetRepository implements LearningAssetRepository
     if (!Number.isInteger(query.limit) || query.limit < 1 || query.limit > 500) {
       throw new RangeError('Learning asset query limit must be between 1 and 500');
     }
+    const offset = query.offset ?? 0;
+    if (!Number.isInteger(offset) || offset < 0) throw new RangeError('Learning asset query offset must be a non-negative integer');
     return (await this.database.getAll<LearningAssetRecord>(TutorIndexedDbStore.LearningAssets))
       .filter((item) => item.examCycleId === query.examCycleId)
       .filter((item) => !query.kinds?.length || query.kinds.includes(item.kind))
       .filter((item) => !query.businessKey || item.businessKey === query.businessKey)
       .filter((item) => !query.status || item.status === query.status)
       .sort(compareLatest)
-      .slice(0, query.limit);
+      .slice(offset, offset + query.limit);
   }
 
   async listAll(examCycleId: ExamCycleId): Promise<readonly LearningAssetRecord[]> {

--- a/web/src/modules/content/adapters/SqliteLearningAssetRepository.ts
+++ b/web/src/modules/content/adapters/SqliteLearningAssetRepository.ts
@@ -100,6 +100,8 @@ export class SqliteLearningAssetRepository implements LearningAssetRepository {
     if (!Number.isInteger(query.limit) || query.limit < 1 || query.limit > 500) {
       throw new RangeError('Learning asset query limit must be between 1 and 500');
     }
+    const offset = query.offset ?? 0;
+    if (!Number.isInteger(offset) || offset < 0) throw new RangeError('Learning asset query offset must be a non-negative integer');
     const conditions = ['exam_cycle_id=?'];
     const parameters: Array<string | number> = [query.examCycleId];
     if (query.kinds?.length) {
@@ -114,10 +116,10 @@ export class SqliteLearningAssetRepository implements LearningAssetRepository {
       conditions.push('status=?');
       parameters.push(query.status);
     }
-    parameters.push(query.limit);
+    parameters.push(query.limit, offset);
     const rows = await this.database.query<LearningAssetRow>(
       `SELECT * FROM learning_assets WHERE ${conditions.join(' AND ')}
-       ORDER BY updated_at DESC,version DESC,id DESC LIMIT ?`,
+       ORDER BY updated_at DESC,version DESC,id DESC LIMIT ? OFFSET ?`,
       parameters
     );
     return rows.map(mapRow);

--- a/web/src/modules/content/contracts/LearningAssetRepository.ts
+++ b/web/src/modules/content/contracts/LearningAssetRepository.ts
@@ -21,6 +21,7 @@ export interface LearningAssetQuery {
   readonly kinds?: readonly LearningAssetKind[];
   readonly businessKey?: string;
   readonly status?: LearningAssetStatus;
+  readonly offset?: number;
   readonly limit: number;
 }
 

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -28,7 +28,7 @@ const routes: RouteRecordRaw[] = [
   },
   {
     path: '/essay',
-    redirect: '/vue/essay'
+    redirect: { path: '/vue/practice', query: { subject: 'essay', mode: 'tutor' } }
   },
   {
     path: '/calendar',

--- a/web/src/services/AIBusinessTools.ts
+++ b/web/src/services/AIBusinessTools.ts
@@ -1,5 +1,5 @@
 import { digestService } from '@/services/DigestService';
-import { essayFlowService } from '@/services/EssayFlowService';
+import { essayFlowService, type EssayGenerationContext } from '@/services/EssayFlowService';
 import { examFlowService } from '@/services/ExamFlowService';
 import { monthlyDigestService } from '@/services/MonthlyDigestService';
 import { initializeTutorRuntime } from '@/composition-root/public';
@@ -113,11 +113,13 @@ export class AIBusinessTools {
     if (call.name === 'generate_essay') {
       const essayTopic = asString(args.essayTopic) || '申论小题';
       const essayType = args.essayType === 'long' || essayTopic === '申发论述' ? 'long' : 'short';
-      const context = essayFlowService.writeContext({
+      const context: EssayGenerationContext = {
         date: today(),
         topic: essayTopic,
-        type: essayType
-      });
+        type: essayType,
+        entryMode: 'self' as const,
+        purpose: 'practice' as const
+      };
       const result = await essayFlowService.enqueueQuestionGeneration(context, {
         questionCount: asNumber(args.questionCount, 1),
         idempotencyKey: meta.idempotencyKey

--- a/web/src/services/EssayFlowService.ts
+++ b/web/src/services/EssayFlowService.ts
@@ -1,7 +1,13 @@
 import { generationTaskService } from './GenerationTaskService';
 import type { AgentTaskEnqueueResult } from './GenerationTaskService';
+import {
+  createEssayQuestionSetId,
+  essayQuestionSetGenerationScope,
+  normalizeEssayQuestionSetMode
+} from '@/domain/essayQuestionSet';
 
 export interface EssayContext {
+  questionSetId?: string;
   date: string;
   topic: string;
   type: 'short' | 'long';
@@ -49,12 +55,14 @@ export class EssayFlowService {
       intent: 'essayGrade',
       title: '申论批改',
       detail: `${context.topic} · ${context.date}`,
-      sourceId: `${context.topic}:${context.date}`,
+      sourceId: context.questionSetId || `${context.topic}:${context.date}`,
       payload: {
         content,
+        questionSetId: context.questionSetId,
         essayDate: context.date,
         essayTopic: context.topic,
-        essayType: context.type
+        essayType: context.type,
+        entryMode: normalizeEssayQuestionSetMode(context.entryMode)
       }
     });
   }
@@ -64,19 +72,23 @@ export class EssayFlowService {
     options: { questionCount?: number; title?: string; idempotencyKey?: string } = {}
   ): Promise<AgentTaskEnqueueResult> {
     const count = Math.max(1, Math.min(3, Number(options.questionCount || 1)));
+    const questionSetId = context.questionSetId?.trim() || createEssayQuestionSetId();
+    const entryMode = normalizeEssayQuestionSetMode(context.entryMode);
     return generationTaskService.enqueue({
       idempotencyKey: options.idempotencyKey,
       intent: 'mock',
       title: options.title || '生成申论题目',
       detail: `${context.topic} · ${count} 题 · ${context.date}`,
       module: '申论',
-      sourceId: `essay:${context.entryMode || 'self'}:${context.topic}:${context.date}:${context.type}:${count}`,
+      sourceId: questionSetId,
+      scopeId: essayQuestionSetGenerationScope({ ...context, questionSetId, entryMode }),
       payload: {
         subject: '申论',
+        questionSetId,
         date: context.date,
         essayTopic: context.topic,
         essayType: context.type,
-        entryMode: context.entryMode || 'self',
+        entryMode,
         essayQuestionCount: count
       }
     });

--- a/web/src/services/EssayFlowService.ts
+++ b/web/src/services/EssayFlowService.ts
@@ -3,15 +3,22 @@ import type { AgentTaskEnqueueResult } from './GenerationTaskService';
 import {
   createEssayQuestionSetId,
   essayQuestionSetGenerationScope,
-  normalizeEssayQuestionSetMode
+  normalizeEssayQuestionSetMode,
+  normalizeEssayQuestionSetPurpose,
+  type EssayQuestionSetPurpose
 } from '@/domain/essayQuestionSet';
 
-export interface EssayContext {
+export interface EssayGenerationContext {
   questionSetId?: string;
   date: string;
   topic: string;
   type: 'short' | 'long';
   entryMode?: EssayEntryMode;
+  purpose?: EssayQuestionSetPurpose;
+}
+
+export interface EssayContext extends EssayGenerationContext {
+  questionSetId: string;
 }
 
 export type EssayEntryMode = 'tutor' | 'self' | 'true';
@@ -27,7 +34,7 @@ function typeFromTopic(topic: string): EssayContext['type'] {
 }
 
 export class EssayFlowService {
-  readContext(): EssayContext {
+  readGenerationDefaults(): EssayGenerationContext {
     const date = localStorage.getItem('es-date') || today();
     const topic = localStorage.getItem('essay-topic') || '申论';
     return {
@@ -37,17 +44,24 @@ export class EssayFlowService {
     };
   }
 
-  writeContext(patch: Partial<EssayContext>): EssayContext {
-    const next = { ...this.readContext(), ...patch };
-    localStorage.setItem('es-date', next.date);
-    if (next.topic && next.topic !== '申论') localStorage.setItem('essay-topic', next.topic);
+  writeContext(context: EssayContext): EssayContext {
+    const questionSetId = context.questionSetId.trim();
+    if (!questionSetId) throw new TypeError('Essay context requires questionSetId');
+    const next: EssayContext = {
+      ...context,
+      questionSetId,
+      entryMode: normalizeEssayQuestionSetMode(context.entryMode),
+      purpose: normalizeEssayQuestionSetPurpose(context.purpose, context.entryMode)
+    };
+    localStorage.setItem('es-date', context.date);
+    if (context.topic && context.topic !== '申论') localStorage.setItem('essay-topic', context.topic);
     else localStorage.removeItem('essay-topic');
     return next;
   }
 
   async enqueueGrading(
     content: string,
-    context = this.readContext(),
+    context: EssayContext,
     idempotencyKey?: string
   ): Promise<AgentTaskEnqueueResult> {
     return generationTaskService.enqueue({
@@ -62,18 +76,20 @@ export class EssayFlowService {
         essayDate: context.date,
         essayTopic: context.topic,
         essayType: context.type,
-        entryMode: normalizeEssayQuestionSetMode(context.entryMode)
+        entryMode: normalizeEssayQuestionSetMode(context.entryMode),
+        purpose: normalizeEssayQuestionSetPurpose(context.purpose, context.entryMode)
       }
     });
   }
 
   async enqueueQuestionGeneration(
-    context = this.readContext(),
+    context: EssayGenerationContext,
     options: { questionCount?: number; title?: string; idempotencyKey?: string } = {}
   ): Promise<AgentTaskEnqueueResult> {
     const count = Math.max(1, Math.min(3, Number(options.questionCount || 1)));
     const questionSetId = context.questionSetId?.trim() || createEssayQuestionSetId();
     const entryMode = normalizeEssayQuestionSetMode(context.entryMode);
+    const purpose = normalizeEssayQuestionSetPurpose(context.purpose, entryMode);
     return generationTaskService.enqueue({
       idempotencyKey: options.idempotencyKey,
       intent: 'mock',
@@ -81,7 +97,7 @@ export class EssayFlowService {
       detail: `${context.topic} · ${count} 题 · ${context.date}`,
       module: '申论',
       sourceId: questionSetId,
-      scopeId: essayQuestionSetGenerationScope({ ...context, questionSetId, entryMode }),
+      scopeId: essayQuestionSetGenerationScope({ ...context, questionSetId, entryMode, purpose }),
       payload: {
         subject: '申论',
         questionSetId,
@@ -89,6 +105,7 @@ export class EssayFlowService {
         essayTopic: context.topic,
         essayType: context.type,
         entryMode,
+        purpose,
         essayQuestionCount: count
       }
     });

--- a/web/src/services/EssayRepository.ts
+++ b/web/src/services/EssayRepository.ts
@@ -6,7 +6,11 @@ import {
   type LearningAssetRecord
 } from '@/modules/content/public';
 import type { EssayContext } from './EssayFlowService';
-import { essayQuestionSetBusinessKey, normalizeEssayQuestionSetMode } from '@/domain/essayQuestionSet';
+import {
+  essayQuestionSetBusinessKey,
+  normalizeEssayQuestionSetMode,
+  normalizeEssayQuestionSetPurpose
+} from '@/domain/essayQuestionSet';
 
 export interface EssayQuestionRecord {
   id: string;
@@ -55,18 +59,26 @@ export interface EssayLocalState {
   updatedAt: number;
 }
 
-export interface EssayStateHistoryItem {
+export interface EssayQuestionSetSummary {
   key: string;
   context: EssayContext;
-  state: EssayLocalState;
+  question: EssayQuestionRecord | null;
+  updatedAt: number;
 }
 
 function today(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-function normalizeContext(context?: EssayContext): EssayContext {
-  return context ?? { date: today(), topic: '申论', type: 'short' };
+function normalizeContext(context: EssayContext): EssayContext {
+  const questionSetId = context.questionSetId.trim();
+  if (!questionSetId) throw new TypeError('Essay repository requires questionSetId');
+  return {
+    ...context,
+    questionSetId,
+    entryMode: normalizeEssayQuestionSetMode(context.entryMode),
+    purpose: normalizeEssayQuestionSetPurpose(context.purpose, context.entryMode)
+  };
 }
 
 function businessKey(context: EssayContext): string {
@@ -112,7 +124,7 @@ function historyFromAsset(asset: LearningAssetRecord): EssayHistoryRecord | unde
 export class EssayRepository {
   constructor(private readonly runtimeProvider: () => Promise<TutorDatabaseRuntime> = defaultRuntimeProvider) {}
 
-  async getState(context?: EssayContext): Promise<EssayLocalState> {
+  async getState(context: EssayContext): Promise<EssayLocalState> {
     const normalized = normalizeContext(context);
     const key = businessKey(normalized);
     const { runtime, examCycleId } = await this.activeCycle();
@@ -140,7 +152,7 @@ export class EssayRepository {
     };
   }
 
-  async saveDraft(draft: string, context?: EssayContext): Promise<EssayLocalState> {
+  async saveDraft(draft: string, context: EssayContext): Promise<EssayLocalState> {
     const normalized = normalizeContext(context);
     const { runtime, examCycleId } = await this.activeCycle();
     await runtime.learningAssetStore.saveDraft({
@@ -153,7 +165,7 @@ export class EssayRepository {
     return this.getState(normalized);
   }
 
-  async saveQuestion(question: EssayQuestionRecord, context?: EssayContext): Promise<EssayLocalState> {
+  async saveQuestion(question: EssayQuestionRecord, context: EssayContext): Promise<EssayLocalState> {
     const normalized = normalizeContext(context);
     const { runtime, examCycleId } = await this.activeCycle();
     await runtime.learningAssetStore.save({
@@ -174,12 +186,12 @@ export class EssayRepository {
   async saveFeedback(
     content: string,
     feedback: string,
-    structured?: {
+    structured: {
       score?: number;
       dimensions?: EssayFeedbackDimension[];
       suggestions?: string[];
-    },
-    context?: EssayContext
+    } | undefined,
+    context: EssayContext
   ): Promise<EssayLocalState> {
     const normalized = normalizeContext(context);
     const current = await this.getState(normalized);
@@ -205,11 +217,11 @@ export class EssayRepository {
     return this.getState(normalized);
   }
 
-  async resetDraft(context?: EssayContext): Promise<EssayLocalState> {
+  async resetDraft(context: EssayContext): Promise<EssayLocalState> {
     return this.saveDraft('', context);
   }
 
-  async deleteState(context?: EssayContext): Promise<EssayLocalState> {
+  async deleteState(context: EssayContext): Promise<EssayLocalState> {
     const normalized = normalizeContext(context);
     const { runtime, examCycleId } = await this.activeCycle();
     await Promise.all([
@@ -220,7 +232,7 @@ export class EssayRepository {
     return this.getState(normalized);
   }
 
-  async listStates(): Promise<EssayStateHistoryItem[]> {
+  async listStates(): Promise<EssayQuestionSetSummary[]> {
     const { runtime, examCycleId } = await this.activeCycle();
     const assets = await runtime.learningAssetStore.list({
       examCycleId,
@@ -242,21 +254,17 @@ export class EssayRepository {
         date: typeof record.date === 'string' ? record.date : today(),
         topic: typeof record.topic === 'string' ? record.topic : '申论',
         type: record.type === 'long' ? 'long' : 'short',
-        entryMode: normalizeEssayQuestionSetMode(record.entryMode)
+        entryMode: normalizeEssayQuestionSetMode(record.entryMode),
+        purpose: normalizeEssayQuestionSetPurpose(record.purpose, record.entryMode)
       };
       return {
         key: asset.businessKey,
         context: itemContext,
-        state: {
-          question: asQuestion(asset.payload.question),
-          draft: '',
-          feedback: null,
-          history: [],
-          updatedAt: asset.updatedAt
-        }
+        question: asQuestion(asset.payload.question),
+        updatedAt: asset.updatedAt
       };
     });
-    return items.sort((left, right) => right.state.updatedAt - left.state.updatedAt);
+    return items.sort((left, right) => right.updatedAt - left.updatedAt);
   }
 
   private async activeCycle(): Promise<{ runtime: TutorDatabaseRuntime; examCycleId: ExamCycleId }> {

--- a/web/src/services/EssayRepository.ts
+++ b/web/src/services/EssayRepository.ts
@@ -1,4 +1,4 @@
-import { initializeTutorRuntime } from '@/composition-root/public';
+import type { TutorDatabaseRuntime } from '@/composition-root/public';
 import type { ExamCycleId, JsonObject } from '@/kernel/public';
 import {
   LearningAssetKind,
@@ -6,6 +6,7 @@ import {
   type LearningAssetRecord
 } from '@/modules/content/public';
 import type { EssayContext } from './EssayFlowService';
+import { essayQuestionSetBusinessKey, normalizeEssayQuestionSetMode } from '@/domain/essayQuestionSet';
 
 export interface EssayQuestionRecord {
   id: string;
@@ -69,8 +70,7 @@ function normalizeContext(context?: EssayContext): EssayContext {
 }
 
 function businessKey(context: EssayContext): string {
-  const mode = context.entryMode && context.entryMode !== 'self' ? `:${context.entryMode}` : '';
-  return `essay:${context.date}:${context.topic}:${context.type}${mode}`;
+  return essayQuestionSetBusinessKey(context);
 }
 
 function asQuestion(value: unknown): EssayQuestionRecord | null {
@@ -109,19 +109,13 @@ function historyFromAsset(asset: LearningAssetRecord): EssayHistoryRecord | unde
   };
 }
 
-async function currentCycleId(): Promise<ExamCycleId> {
-  const runtime = await initializeTutorRuntime();
-  const cycle = await runtime.candidateRepository.findCurrentCycle();
-  if (!cycle) throw new Error('请先完成备考档案。');
-  return cycle.examCycle.id;
-}
-
 export class EssayRepository {
+  constructor(private readonly runtimeProvider: () => Promise<TutorDatabaseRuntime> = defaultRuntimeProvider) {}
+
   async getState(context?: EssayContext): Promise<EssayLocalState> {
     const normalized = normalizeContext(context);
     const key = businessKey(normalized);
-    const runtime = await initializeTutorRuntime();
-    const examCycleId = await currentCycleId();
+    const { runtime, examCycleId } = await this.activeCycle();
     const [questionAsset, draftAsset, attemptAssets] = await Promise.all([
       runtime.learningAssetStore.findLatest(examCycleId, LearningAssetKind.EssayQuestion, key),
       runtime.learningAssetStore.findLatest(examCycleId, LearningAssetKind.EssayDraft, key),
@@ -148,9 +142,9 @@ export class EssayRepository {
 
   async saveDraft(draft: string, context?: EssayContext): Promise<EssayLocalState> {
     const normalized = normalizeContext(context);
-    const runtime = await initializeTutorRuntime();
+    const { runtime, examCycleId } = await this.activeCycle();
     await runtime.learningAssetStore.saveDraft({
-      examCycleId: await currentCycleId(),
+      examCycleId,
       kind: LearningAssetKind.EssayDraft,
       businessKey: businessKey(normalized),
       title: `${normalized.topic}草稿 · ${normalized.date}`,
@@ -161,8 +155,7 @@ export class EssayRepository {
 
   async saveQuestion(question: EssayQuestionRecord, context?: EssayContext): Promise<EssayLocalState> {
     const normalized = normalizeContext(context);
-    const runtime = await initializeTutorRuntime();
-    const examCycleId = await currentCycleId();
+    const { runtime, examCycleId } = await this.activeCycle();
     await runtime.learningAssetStore.save({
       examCycleId,
       kind: LearningAssetKind.EssayQuestion,
@@ -191,9 +184,9 @@ export class EssayRepository {
     const normalized = normalizeContext(context);
     const current = await this.getState(normalized);
     if (!current.question) throw new Error('当前没有申论题目，无法保存批改记录');
-    const runtime = await initializeTutorRuntime();
+    const { runtime, examCycleId } = await this.activeCycle();
     await runtime.learningAssetStore.save({
-      examCycleId: await currentCycleId(),
+      examCycleId,
       kind: LearningAssetKind.EssayAttempt,
       businessKey: businessKey(normalized),
       title: `${current.question.title} · 批改`,
@@ -218,8 +211,7 @@ export class EssayRepository {
 
   async deleteState(context?: EssayContext): Promise<EssayLocalState> {
     const normalized = normalizeContext(context);
-    const runtime = await initializeTutorRuntime();
-    const examCycleId = await currentCycleId();
+    const { runtime, examCycleId } = await this.activeCycle();
     await Promise.all([
       runtime.learningAssetStore.retireBusinessKey(examCycleId, LearningAssetKind.EssayQuestion, businessKey(normalized)),
       runtime.learningAssetStore.retireBusinessKey(examCycleId, LearningAssetKind.EssayDraft, businessKey(normalized)),
@@ -229,8 +221,7 @@ export class EssayRepository {
   }
 
   async listStates(): Promise<EssayStateHistoryItem[]> {
-    const runtime = await initializeTutorRuntime();
-    const examCycleId = await currentCycleId();
+    const { runtime, examCycleId } = await this.activeCycle();
     const assets = await runtime.learningAssetStore.list({
       examCycleId,
       kinds: [LearningAssetKind.EssayQuestion],
@@ -241,25 +232,44 @@ export class EssayRepository {
     assets.forEach((asset) => {
       if (!latest.has(asset.businessKey)) latest.set(asset.businessKey, asset);
     });
-    const items = await Promise.all(Array.from(latest.values()).map(async (asset) => {
+    const items = Array.from(latest.values()).map((asset) => {
       const rawContext = asset.payload.essayContext;
       const record = rawContext && typeof rawContext === 'object' && !Array.isArray(rawContext)
         ? rawContext as Record<string, unknown>
         : {};
       const itemContext: EssayContext = {
+        questionSetId: asset.businessKey,
         date: typeof record.date === 'string' ? record.date : today(),
         topic: typeof record.topic === 'string' ? record.topic : '申论',
         type: record.type === 'long' ? 'long' : 'short',
-        entryMode: record.entryMode === 'tutor' || record.entryMode === 'true' ? record.entryMode : 'self'
+        entryMode: normalizeEssayQuestionSetMode(record.entryMode)
       };
       return {
         key: asset.businessKey,
         context: itemContext,
-        state: await this.getState(itemContext)
+        state: {
+          question: asQuestion(asset.payload.question),
+          draft: '',
+          feedback: null,
+          history: [],
+          updatedAt: asset.updatedAt
+        }
       };
-    }));
+    });
     return items.sort((left, right) => right.state.updatedAt - left.state.updatedAt);
   }
+
+  private async activeCycle(): Promise<{ runtime: TutorDatabaseRuntime; examCycleId: ExamCycleId }> {
+    const runtime = await this.runtimeProvider();
+    const cycle = await runtime.candidateRepository.findCurrentCycle();
+    if (!cycle) throw new Error('请先完成备考档案。');
+    return { runtime, examCycleId: cycle.examCycle.id };
+  }
+}
+
+async function defaultRuntimeProvider(): Promise<TutorDatabaseRuntime> {
+  const { initializeTutorRuntime } = await import('@/composition-root/public');
+  return initializeTutorRuntime();
 }
 
 export const essayRepository = new EssayRepository();

--- a/web/src/services/ExamFlowService.ts
+++ b/web/src/services/ExamFlowService.ts
@@ -1,9 +1,17 @@
 import { initializeTutorRuntime } from '@/composition-root/public';
-import { LearningAssetKind, LearningAssetStatus } from '@/modules/content/public';
+import {
+  LearningAssetKind,
+  LearningAssetStatus,
+  type LearningAssetRecord
+} from '@/modules/content/public';
 import { generationTaskService } from './GenerationTaskService';
 import { essayFlowService } from './EssayFlowService';
 import type { AgentTaskEnqueueResult } from './GenerationTaskService';
-import { normalizeEssayQuestionSetMode, type EssayQuestionSetMode } from '@/domain/essayQuestionSet';
+import {
+  normalizeEssayQuestionSetMode,
+  isEssayMockContext,
+  type EssayQuestionSetMode
+} from '@/domain/essayQuestionSet';
 
 export type ExamSubject = '行测' | '申论';
 export type EssayMockType = 'short' | 'long';
@@ -38,6 +46,7 @@ export interface ExamHistoryItem {
   essayEntryMode?: EssayQuestionSetMode;
   essayTopic?: string;
   essayType?: EssayMockType;
+  essayPurpose?: 'mock';
 }
 
 export interface ExamStats {
@@ -137,12 +146,14 @@ export class ExamFlowService {
     const runtime = await initializeTutorRuntime();
     const cycle = await runtime.candidateRepository.findCurrentCycle();
     if (!cycle) throw new Error('请先完成备考档案。');
-    const assets = await runtime.learningAssetStore.list({
-      examCycleId: cycle.examCycle.id,
-      kinds: subject === '行测' ? [LearningAssetKind.MockManifest] : [LearningAssetKind.EssayQuestion],
-      status: LearningAssetStatus.Ready,
-      limit: 100
-    });
+    const assets = subject === '行测'
+      ? await runtime.learningAssetStore.list({
+        examCycleId: cycle.examCycle.id,
+        kinds: [LearningAssetKind.MockManifest],
+        status: LearningAssetStatus.Ready,
+        limit: 100
+      })
+      : await listEssayMockAssets(runtime, cycle.examCycle.id, 30);
     const recentSessions = subject === '行测'
       ? await runtime.learningSessionRepository.listRecent(cycle.examCycle.id, 500)
       : [];
@@ -162,6 +173,7 @@ export class ExamFlowService {
             essayEntryMode: normalizeEssayQuestionSetMode(essayContext.entryMode),
             essayTopic: typeof essayContext.topic === 'string' ? essayContext.topic : asset.title,
             essayType: essayContext.type === 'long' ? 'long' : 'short',
+            essayPurpose: 'mock',
             questionCount: 1,
             correctCount: 0,
             accuracy: 0,
@@ -230,10 +242,42 @@ export class ExamFlowService {
       date: normalized.date,
       topic,
       type: normalized.essayType,
-      entryMode: 'self'
+      entryMode: 'self',
+      purpose: 'mock'
     }, { questionCount: 1, title: '申论模考', idempotencyKey });
   }
 
 }
 
 export const examFlowService = new ExamFlowService();
+
+async function listEssayMockAssets(
+  runtime: Awaited<ReturnType<typeof initializeTutorRuntime>>,
+  examCycleId: Parameters<typeof runtime.learningAssetStore.list>[0]['examCycleId'],
+  targetCount: number
+) {
+  const pageSize = 100;
+  const matches: LearningAssetRecord[] = [];
+  const seenBusinessKeys = new Set<string>();
+  for (let offset = 0; matches.length < targetCount; offset += pageSize) {
+    const page = await runtime.learningAssetStore.list({
+      examCycleId,
+      kinds: [LearningAssetKind.EssayQuestion],
+      status: LearningAssetStatus.Ready,
+      offset,
+      limit: pageSize
+    });
+    for (const asset of page) {
+      if (!isEssayMockAsset(asset) || seenBusinessKeys.has(asset.businessKey)) continue;
+      seenBusinessKeys.add(asset.businessKey);
+      matches.push(asset);
+      if (matches.length >= targetCount) break;
+    }
+    if (page.length < pageSize) break;
+  }
+  return matches.slice(0, targetCount);
+}
+
+export function isEssayMockAsset(asset: LearningAssetRecord): boolean {
+  return isEssayMockContext(asset.payload.essayContext);
+}

--- a/web/src/services/ExamFlowService.ts
+++ b/web/src/services/ExamFlowService.ts
@@ -3,6 +3,7 @@ import { LearningAssetKind, LearningAssetStatus } from '@/modules/content/public
 import { generationTaskService } from './GenerationTaskService';
 import { essayFlowService } from './EssayFlowService';
 import type { AgentTaskEnqueueResult } from './GenerationTaskService';
+import { normalizeEssayQuestionSetMode, type EssayQuestionSetMode } from '@/domain/essayQuestionSet';
 
 export type ExamSubject = '行测' | '申论';
 export type EssayMockType = 'short' | 'long';
@@ -33,6 +34,10 @@ export interface ExamHistoryItem {
   durationMs?: number;
   createdAt: number;
   manifestId?: string;
+  questionSetId?: string;
+  essayEntryMode?: EssayQuestionSetMode;
+  essayTopic?: string;
+  essayType?: EssayMockType;
 }
 
 export interface ExamStats {
@@ -153,6 +158,10 @@ export class ExamFlowService {
             subject,
             date,
             title: asset.title,
+            questionSetId: asset.businessKey,
+            essayEntryMode: normalizeEssayQuestionSetMode(essayContext.entryMode),
+            essayTopic: typeof essayContext.topic === 'string' ? essayContext.topic : asset.title,
+            essayType: essayContext.type === 'long' ? 'long' : 'short',
             questionCount: 1,
             correctCount: 0,
             accuracy: 0,
@@ -217,25 +226,12 @@ export class ExamFlowService {
     }
 
     const topic = normalized.essayType === 'long' ? '申发论述' : '申论小题';
-    essayFlowService.writeContext({
+    return essayFlowService.enqueueQuestionGeneration({
       date: normalized.date,
       topic,
-      type: normalized.essayType
-    });
-    return generationTaskService.enqueue({
-      idempotencyKey,
-      intent: 'mock',
-      title: '申论模考',
-      detail: `${topic} · ${normalized.date}`,
-      module: '申论',
-      sourceId: `mock:申论:${normalized.date}:${normalized.essayType}`,
-      payload: {
-        subject: '申论',
-        date: normalized.date,
-        essayTopic: topic,
-        essayType: normalized.essayType
-      }
-    });
+      type: normalized.essayType,
+      entryMode: 'self'
+    }, { questionCount: 1, title: '申论模考', idempotencyKey });
   }
 
 }

--- a/web/src/services/GenerationTaskContract.ts
+++ b/web/src/services/GenerationTaskContract.ts
@@ -41,7 +41,9 @@ export function generationTaskActionParams(input: GenerationTaskInput): JsonObje
       entryMode: text(input.payload?.entryMode) || 'self',
       ...(text(input.payload?.questionSetId) ? { questionSetId: text(input.payload?.questionSetId)! } : {}),
       topic: text(input.payload?.essayTopic) || '申论',
-      date: text(input.payload?.essayDate) || ''
+      date: text(input.payload?.essayDate) || '',
+      type: text(input.payload?.essayType) === 'long' ? 'long' : 'short',
+      purpose: text(input.payload?.purpose) || 'practice'
     };
   }
   if (input.intent === 'mock' && input.payload?.subject === '申论') {
@@ -51,6 +53,8 @@ export function generationTaskActionParams(input: GenerationTaskInput): JsonObje
       ...(text(input.payload?.questionSetId) ? { questionSetId: text(input.payload?.questionSetId)! } : {}),
       topic: text(input.payload?.essayTopic) || '申论',
       date: text(input.payload?.date) || '',
+      type: text(input.payload?.essayType) === 'long' ? 'long' : 'short',
+      purpose: text(input.payload?.purpose) || 'practice',
       questionCount: Number(input.payload?.essayQuestionCount || 1)
     };
   }

--- a/web/src/services/GenerationTaskContract.ts
+++ b/web/src/services/GenerationTaskContract.ts
@@ -1,0 +1,62 @@
+import type { JsonObject } from '@/kernel/public';
+
+export type GenerationIntent =
+  | 'daily'
+  | 'practice'
+  | 'essayGrade'
+  | 'mock'
+  | 'redo'
+  | 'digest'
+  | 'monthlyDigest'
+  | 'study'
+  | 'interviewReview'
+  | 'trueQuestionResearch';
+
+export interface GenerationTaskInput {
+  readonly intent: GenerationIntent;
+  readonly idempotencyKey?: string;
+  readonly title?: string;
+  readonly detail?: string;
+  readonly module?: string;
+  readonly sourceId?: string;
+  readonly scopeId?: string;
+  readonly payload?: Record<string, unknown>;
+}
+
+export function generationTaskScope(projectId: string, input: GenerationTaskInput): string {
+  const source = input.scopeId || input.sourceId || input.module || input.intent;
+  return `${input.intent}:${projectId}:${source}`;
+}
+
+export function generationTaskActionParams(input: GenerationTaskInput): JsonObject {
+  const linkage = {
+    ...(text(input.payload?.dailyPlanItemId) ? { dailyPlanItemId: text(input.payload?.dailyPlanItemId)! } : {}),
+    ...(text(input.payload?.capabilityNodeId) ? { capabilityNodeId: text(input.payload?.capabilityNodeId)! } : {}),
+    ...(text(input.payload?.reviewQueueItemId) ? { reviewQueueItemId: text(input.payload?.reviewQueueItemId)! } : {})
+  };
+  if (input.intent === 'trueQuestionResearch') return { mode: 'true', ...linkage };
+  if (input.intent === 'essayGrade') {
+    return {
+      ...linkage,
+      entryMode: text(input.payload?.entryMode) || 'self',
+      ...(text(input.payload?.questionSetId) ? { questionSetId: text(input.payload?.questionSetId)! } : {}),
+      topic: text(input.payload?.essayTopic) || '申论',
+      date: text(input.payload?.essayDate) || ''
+    };
+  }
+  if (input.intent === 'mock' && input.payload?.subject === '申论') {
+    return {
+      ...linkage,
+      entryMode: text(input.payload?.entryMode) || 'self',
+      ...(text(input.payload?.questionSetId) ? { questionSetId: text(input.payload?.questionSetId)! } : {}),
+      topic: text(input.payload?.essayTopic) || '申论',
+      date: text(input.payload?.date) || '',
+      questionCount: Number(input.payload?.essayQuestionCount || 1)
+    };
+  }
+  return linkage;
+}
+
+function text(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}

--- a/web/src/services/GenerationTaskService.ts
+++ b/web/src/services/GenerationTaskService.ts
@@ -13,28 +13,19 @@ import {
   MessageSeverity,
   MessageSourceType
 } from '@/modules/message-center/public';
+import {
+  generationTaskActionParams,
+  generationTaskScope,
+  type GenerationIntent,
+  type GenerationTaskInput
+} from './GenerationTaskContract';
 
-export type GenerationIntent =
-  | 'daily'
-  | 'practice'
-  | 'essayGrade'
-  | 'mock'
-  | 'redo'
-  | 'digest'
-  | 'monthlyDigest'
-  | 'study'
-  | 'interviewReview'
-  | 'trueQuestionResearch';
-
-export interface GenerationTaskInput {
-  readonly intent: GenerationIntent;
-  readonly idempotencyKey?: string;
-  readonly title?: string;
-  readonly detail?: string;
-  readonly module?: string;
-  readonly sourceId?: string;
-  readonly payload?: Record<string, unknown>;
-}
+export {
+  generationTaskActionParams,
+  generationTaskScope,
+  type GenerationIntent,
+  type GenerationTaskInput
+} from './GenerationTaskContract';
 
 export interface AgentTaskEnqueueResult {
   readonly task: AgentRunView;
@@ -63,7 +54,7 @@ export class GenerationTaskService {
       throw new Error('当前还没有完整备考档案，请先补全目标、现状和学习时间。');
     }
     const projectId = cycle?.project.id ?? 'unbound';
-    const scopeKey = taskScope(projectId, input);
+    const scopeKey = generationTaskScope(projectId, input);
     const active = await runtime.getAgentRunViews.findActiveByTarget(TaskTargetType.BusinessOperation, scopeKey);
     if (active) {
       agentWorkerCoordinator.start(runtime);
@@ -73,7 +64,7 @@ export class GenerationTaskService {
     const title = input.title || TITLE_BY_INTENT[input.intent];
     const detail = input.detail || input.module || '准备执行';
     const actionRoute = routeForInput(input);
-    const actionParams = actionParamsForInput(input);
+    const actionParams = generationTaskActionParams(input);
     const dailyPlanItemId = optionalText(input.payload?.dailyPlanItemId);
     const capabilityNodeId = optionalText(input.payload?.capabilityNodeId);
     const aggregate = await runtime.createAgentRun.execute({
@@ -127,11 +118,6 @@ async function requireRunView(runtime: TutorDatabaseRuntime, id: AgentRunView['i
   return run;
 }
 
-function taskScope(projectId: string, input: GenerationTaskInput): string {
-  const source = input.sourceId || input.module || input.intent;
-  return `${input.intent}:${projectId}:${source}`;
-}
-
 function runTypeForIntent(intent: GenerationIntent): AgentRunType {
   if (intent === 'daily' || intent === 'monthlyDigest') return AgentRunType.TeachingPlan;
   if (intent === 'essayGrade' || intent === 'interviewReview') return AgentRunType.TutorTurn;
@@ -159,25 +145,6 @@ function routeForInput(input: GenerationTaskInput): string {
   if (intent === 'trueQuestionResearch') return '/vue/practice';
   if (intent === 'daily' || intent === 'digest') return '/vue/digest';
   return '/vue/study';
-}
-
-function actionParamsForInput(input: GenerationTaskInput): JsonObject {
-  const linkage = {
-    ...(optionalText(input.payload?.dailyPlanItemId) ? { dailyPlanItemId: optionalText(input.payload?.dailyPlanItemId)! } : {}),
-    ...(optionalText(input.payload?.capabilityNodeId) ? { capabilityNodeId: optionalText(input.payload?.capabilityNodeId)! } : {}),
-    ...(optionalText(input.payload?.reviewQueueItemId) ? { reviewQueueItemId: optionalText(input.payload?.reviewQueueItemId)! } : {})
-  };
-  if (input.intent === 'trueQuestionResearch') return { mode: 'true', ...linkage };
-  if (input.intent === 'mock' && input.payload?.subject === '申论') {
-    return {
-      ...linkage,
-      mode: optionalText(input.payload?.entryMode) || 'self',
-      topic: optionalText(input.payload?.essayTopic) || '申论',
-      date: optionalText(input.payload?.date) || '',
-      questionCount: Number(input.payload?.essayQuestionCount || 1)
-    };
-  }
-  return linkage;
 }
 
 function optionalText(value: unknown): string | undefined {

--- a/web/src/stores/essay.ts
+++ b/web/src/stores/essay.ts
@@ -42,7 +42,7 @@ export const useEssayStore = defineStore('essay', {
   }),
 
   actions: {
-    async fetchQuestion(context: EssayContext = essayFlowService.readContext()) {
+    async fetchQuestion(context: EssayContext) {
       this.isLoading = true;
       this.error = null;
       try {
@@ -63,7 +63,8 @@ export const useEssayStore = defineStore('essay', {
       this.submission.content = content;
       this.submission.feedback = null;
       this.submitMessage = '';
-      void essayRepository.saveDraft(content, this.context || essayFlowService.readContext());
+      const context = requireEssayContext(this.context);
+      void essayRepository.saveDraft(content, context);
     },
 
     async submitForGrading() {
@@ -71,7 +72,7 @@ export const useEssayStore = defineStore('essay', {
       this.submission.feedback = null;
       this.submitMessage = '';
       try {
-        await essayFlowService.enqueueGrading(this.submission.content, this.context || essayFlowService.readContext());
+        await essayFlowService.enqueueGrading(this.submission.content, requireEssayContext(this.context));
         this.submitMessage = '批改任务已提交，可在任务栏查看进度。';
       } finally {
         this.submission.isSubmitting = false;
@@ -79,7 +80,7 @@ export const useEssayStore = defineStore('essay', {
     },
 
     async resetDraft() {
-      const state = await essayRepository.resetDraft(this.context || essayFlowService.readContext());
+      const state = await essayRepository.resetDraft(requireEssayContext(this.context));
       this.submission.content = state.draft;
       this.submission.feedback = state.feedback;
       this.history = state.history;
@@ -88,10 +89,17 @@ export const useEssayStore = defineStore('essay', {
 
     reset() {
       this.question = null;
-      this.submission.isSubmitting = false;
+      this.submission = { content: '', feedback: null, isSubmitting: false };
+      this.history = [];
       this.context = null;
       this.submitMessage = '';
-      this.isLoading = true;
+      this.isLoading = false;
+      this.error = null;
     }
   },
 });
+
+function requireEssayContext(context: EssayContext | null): EssayContext {
+  if (!context) throw new Error('当前申论题组上下文已失效，请返回刷题中心重新进入。');
+  return context;
+}

--- a/web/src/views/EssayView.vue
+++ b/web/src/views/EssayView.vue
@@ -196,7 +196,7 @@
 
 <script setup lang="ts">
 import { onMounted, onUnmounted, computed, ref } from 'vue';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import { ChevronDownIcon, Clock3Icon, Edit3Icon, FileClockIcon, HistoryIcon, Trash2Icon } from 'lucide-vue-next';
 import BottomSheet from '@/components/layout/BottomSheet.vue';
 import ConfirmDialog from '@/components/layout/ConfirmDialog.vue';
@@ -208,9 +208,15 @@ import type { EssayHistoryRecord, EssayLecture, EssayStateHistoryItem } from '@/
 import { essayRepository } from '@/services/EssayRepository';
 import { useEssayStore } from '@/stores/essay';
 import { essayFlowService } from '@/services/EssayFlowService';
+import {
+  essayCenterLocation,
+  essayQuestionSetLocation,
+  essayQuestionSetTargetFromQuery
+} from '@/features/practice/EssayNavigation';
 
 const store = useEssayStore();
 const route = useRoute();
+const router = useRouter();
 const activeMode = ref<'lecture' | 'question'>('lecture');
 const isAnswerSheetOpen = ref(false);
 const showHistorySheet = ref(false);
@@ -225,16 +231,17 @@ let timerId: number | null = null;
 let resizeStartY = 0;
 let resizeStartHeight = 0;
 
-onMounted(() => {
-  const routeEntryMode = route.query.entryMode === 'tutor' || route.query.entryMode === 'self' || route.query.entryMode === 'true'
-    ? route.query.entryMode
-    : undefined;
+onMounted(async () => {
+  const target = essayQuestionSetTargetFromQuery(route.query);
+  if (!target) {
+    await router.replace(essayCenterLocation());
+    return;
+  }
   const routeContext = essayFlowService.writeContext({
-    ...(typeof route.query.date === 'string' ? { date: route.query.date } : {}),
-    ...(typeof route.query.topic === 'string' ? { topic: route.query.topic } : {}),
-    ...(routeEntryMode ? { entryMode: routeEntryMode } : {})
+    ...target
   });
-  store.fetchQuestion(routeContext).then(() => restoreTimer());
+  await store.fetchQuestion(routeContext);
+  restoreTimer();
   document.addEventListener('visibilitychange', handleVisibilityChange);
 });
 
@@ -321,6 +328,13 @@ async function openQuestionHistoryItem(item: EssayStateHistoryItem) {
   const context = essayFlowService.writeContext(item.context);
   resetTimer();
   await store.fetchQuestion(context);
+  await router.replace(essayQuestionSetLocation({
+    questionSetId: context.questionSetId || item.key,
+    entryMode: context.entryMode,
+    date: context.date,
+    topic: context.topic,
+    type: context.type
+  }));
 }
 
 function openAnswerSheet() {
@@ -385,7 +399,7 @@ function splitRequirement(requirement: string): string[] {
 
 function timerKey() {
   const context = store.context || essayFlowService.readContext();
-  return `essay-timer:${context.topic}:${context.date}`;
+  return `essay-timer:${context.questionSetId || `${context.topic}:${context.date}`}`;
 }
 
 function restoreTimer() {

--- a/web/src/views/EssayView.vue
+++ b/web/src/views/EssayView.vue
@@ -176,7 +176,7 @@
     <BottomSheet v-model="showQuestionHistorySheet" title="历史题目" subtitle="按题型和日期选择" variant="actions">
       <InfiniteScrollPagination :has-more="questionHistoryVisibleCount < questionHistory.length" :has-items="Boolean(questionHistory.length)" :on-load-more="loadMoreQuestionHistory">
         <div v-if="questionHistory.length" class="essay-history-list">
-          <button v-for="item in visibleQuestionHistory" :key="item.key" type="button" @click="openQuestionHistoryItem(item)"><span>{{ item.state.question?.title }}</span><em>{{ item.context.date }} · {{ item.context.topic }}</em>
+          <button v-for="item in visibleQuestionHistory" :key="item.key" type="button" @click="openQuestionHistoryItem(item)"><span>{{ item.question?.title }}</span><em>{{ item.context.date }} · {{ item.context.topic }}</em>
           </button>
         </div>
       </InfiniteScrollPagination>
@@ -204,7 +204,7 @@ import HeaderMoreMenu from '@/components/layout/HeaderMoreMenu.vue';
 import PageHeader from '@/components/layout/PageHeader.vue';
 import MarkdownContent from '@/components/MarkdownContent.vue';
 import { InfiniteScrollPagination } from '@/capabilities/design-system/public';
-import type { EssayHistoryRecord, EssayLecture, EssayStateHistoryItem } from '@/services/EssayRepository';
+import type { EssayHistoryRecord, EssayLecture, EssayQuestionSetSummary } from '@/services/EssayRepository';
 import { essayRepository } from '@/services/EssayRepository';
 import { useEssayStore } from '@/stores/essay';
 import { essayFlowService } from '@/services/EssayFlowService';
@@ -222,30 +222,34 @@ const isAnswerSheetOpen = ref(false);
 const showHistorySheet = ref(false);
 const showQuestionHistorySheet = ref(false);
 const showDeleteConfirmSheet = ref(false);
-const questionHistory = ref<EssayStateHistoryItem[]>([]); const questionHistoryVisibleCount = ref(20);
+const questionHistory = ref<EssayQuestionSetSummary[]>([]); const questionHistoryVisibleCount = ref(20);
 const visibleQuestionHistory = computed(() => questionHistory.value.slice(0, questionHistoryVisibleCount.value));
 const answerSheetHeight = ref(42);
 const elapsedMs = ref(0);
 const isTimerRunning = ref(false);
 let timerId: number | null = null;
+let timerStorageKey: string | null = null;
+let disposed = false;
 let resizeStartY = 0;
 let resizeStartHeight = 0;
 
 onMounted(async () => {
+  document.addEventListener('visibilitychange', handleVisibilityChange);
   const target = essayQuestionSetTargetFromQuery(route.query);
   if (!target) {
+    store.reset();
     await router.replace(essayCenterLocation());
     return;
   }
-  const routeContext = essayFlowService.writeContext({
-    ...target
-  });
+  const routeContext = essayFlowService.writeContext(target);
+  activateTimerOwner(routeContext);
   await store.fetchQuestion(routeContext);
+  if (disposed) return;
   restoreTimer();
-  document.addEventListener('visibilitychange', handleVisibilityChange);
 });
 
 onUnmounted(() => {
+  disposed = true;
   document.removeEventListener('visibilitychange', handleVisibilityChange);
   window.removeEventListener('pointermove', resizeAnswerSheet);
   saveTimer();
@@ -303,7 +307,8 @@ async function confirmDeleteCurrentEssay() {
   isAnswerSheetOpen.value = false;
   activeMode.value = 'lecture';
   resetTimer();
-  const state = await essayRepository.deleteState(store.context || essayFlowService.readContext());
+  if (!store.context) return;
+  const state = await essayRepository.deleteState(store.context);
   store.question = state.question;
   store.submission.content = state.draft;
   store.submission.feedback = state.feedback;
@@ -321,19 +326,25 @@ async function openQuestionHistory() {
   questionHistory.value = await essayRepository.listStates(); questionHistoryVisibleCount.value = 20; showQuestionHistorySheet.value = true;
 }
 function loadMoreQuestionHistory() { questionHistoryVisibleCount.value = Math.min(questionHistory.value.length, questionHistoryVisibleCount.value + 20); }
-async function openQuestionHistoryItem(item: EssayStateHistoryItem) {
+async function openQuestionHistoryItem(item: EssayQuestionSetSummary) {
   showQuestionHistorySheet.value = false;
   isAnswerSheetOpen.value = false;
   activeMode.value = 'lecture';
   const context = essayFlowService.writeContext(item.context);
-  resetTimer();
+  saveTimer();
+  stopTimer();
+  elapsedMs.value = 0;
+  activateTimerOwner(context);
   await store.fetchQuestion(context);
+  if (disposed) return;
+  restoreTimer();
   await router.replace(essayQuestionSetLocation({
-    questionSetId: context.questionSetId || item.key,
+    questionSetId: context.questionSetId,
     entryMode: context.entryMode,
     date: context.date,
     topic: context.topic,
-    type: context.type
+    type: context.type,
+    purpose: context.purpose
   }));
 }
 
@@ -397,14 +408,14 @@ function splitRequirement(requirement: string): string[] {
   return parts.length ? parts : [clean];
 }
 
-function timerKey() {
-  const context = store.context || essayFlowService.readContext();
-  return `essay-timer:${context.questionSetId || `${context.topic}:${context.date}`}`;
+function activateTimerOwner(context: { questionSetId: string }) {
+  timerStorageKey = `essay-timer:${context.questionSetId}`;
 }
 
 function restoreTimer() {
+  if (!timerStorageKey) return;
   try {
-    const raw = localStorage.getItem(timerKey());
+    const raw = localStorage.getItem(timerStorageKey);
     if (!raw) return;
     const saved = JSON.parse(raw) as { elapsedMs?: number; running?: boolean; savedAt?: number };
     elapsedMs.value = saved.elapsedMs || 0;
@@ -418,8 +429,8 @@ function restoreTimer() {
 }
 
 function saveTimer() {
-  if (!store.context) return;
-  localStorage.setItem(timerKey(), JSON.stringify({
+  if (!timerStorageKey) return;
+  localStorage.setItem(timerStorageKey, JSON.stringify({
     elapsedMs: elapsedMs.value,
     running: isTimerRunning.value,
     savedAt: Date.now()
@@ -458,7 +469,7 @@ function resetTimer() {
   stopTimer();
   elapsedMs.value = 0;
   try {
-    localStorage.removeItem(timerKey());
+    if (timerStorageKey) localStorage.removeItem(timerStorageKey);
   } catch {
     // ignore storage failures
   }

--- a/web/src/views/ExamView.vue
+++ b/web/src/views/ExamView.vue
@@ -264,7 +264,7 @@ async function startExam() {
       tags: selectedTags.value,
       essayType: essayType.value
     });
-    notice.value = result.reused ? '已有相同模考任务在执行，已为你打开对应页面。' : '模考任务已加入执行队列。';
+    notice.value = result.reused ? '已有相同模考任务在执行，可在任务栏查看进度。' : '模考任务已加入执行队列。';
   } catch (error) {
     notice.value = error instanceof Error ? error.message : '模考任务派发失败';
   } finally {

--- a/web/src/views/ExamView.vue
+++ b/web/src/views/ExamView.vue
@@ -175,10 +175,9 @@ import PageHeader from '@/components/layout/PageHeader.vue';
 import BottomSheet from '@/components/layout/BottomSheet.vue';
 import { AppStateView, InfiniteScrollPagination, PullToRefresh } from '@/capabilities/design-system/public';
 import { practiceDetailLocation } from '@/features/practice/PracticeNavigation';
-
+import { essayHistoryLocation } from '@/features/practice/EssayNavigation';
 const router = useRouter();
 const subjects: ExamSubject[] = ['行测', '申论'];
-
 const initial = examFlowService.readContext();
 const subject = ref<ExamSubject>(initial.subject);
 const date = ref(initial.date);
@@ -207,7 +206,6 @@ onMounted(async () => {
   await loadDashboard();
   applyDefaultScheme();
 });
-
 async function loadDashboard() {
   isLoading.value = true;
   notice.value = '';
@@ -227,7 +225,6 @@ async function switchSubject(next: ExamSubject) {
   await loadDashboard();
   applyDefaultScheme();
 }
-
 function applyDefaultScheme() {
   if (subject.value !== '行测') return;
   const defaultCount = dashboard.value?.defaultQuestionCount || 120;
@@ -238,7 +235,6 @@ function applyDefaultScheme() {
   questionCount.value = scheme.count;
   durationMinutes.value = scheme.durationMinutes;
 }
-
 function selectScheme(count: number, minutes: number) {
   questionCount.value = count;
   durationMinutes.value = minutes;
@@ -277,11 +273,15 @@ async function startExam() {
 }
 
 function openHistory(item: ExamHistoryItem) {
+  if (subject.value === '申论') {
+    router.push(essayHistoryLocation(item));
+    return;
+  }
   if (item.manifestId) {
     router.push({ path: '/vue/practice/objective-session', query: { manifestId: item.manifestId } });
     return;
   }
-  router.push(subject.value === '申论' ? '/vue/essay' : practiceDetailLocation({ mode: 'self' }));
+  router.push(practiceDetailLocation({ mode: 'self' }));
 }
 
 function durationText(durationMs?: number): string {

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -199,6 +199,7 @@ import {
 import PageHeader from '@/components/layout/PageHeader.vue';
 import { AppStateView, PullToRefresh } from '@/capabilities/design-system/public';
 import { practiceDetailLocation } from '@/features/practice/PracticeNavigation';
+import { essayCenterLocation } from '@/features/practice/EssayNavigation';
 import { initializeTutorRuntime } from '@/composition-root/public';
 import {
   InitialDiagnosisStatus,
@@ -350,7 +351,7 @@ const actionCards = [
   { name: '学习中心', sub: '讲义、积累和路径', icon: BookOpenIcon, color: 'study', to: '/vue/study' },
   { name: '针对性练习', sub: '围绕薄弱点刷题', icon: Edit3Icon, color: 'practice', to: { path: '/vue/practice/session', query: { mode: 'tutor' } } },
   { name: '错题复盘', sub: '错因、闪卡、重做', icon: BookMarkedIcon, color: 'wrong', to: '/vue/wrongbook' },
-  { name: '申论练习', sub: '材料题和批改', icon: FileTextIcon, color: 'essay', to: '/vue/essay' },
+  { name: '申论练习', sub: '材料题和批改', icon: FileTextIcon, color: 'essay', to: essayCenterLocation('tutor') },
   { name: '阶段模考', sub: '校准真实水平', icon: MonitorIcon, color: 'mock', to: '/vue/exam' },
   { name: '完整画像', sub: '质量追踪报告', icon: TargetIcon, color: 'report', to: '/vue/quality-dashboard' }
 ];

--- a/web/src/views/LearningCenterView.vue
+++ b/web/src/views/LearningCenterView.vue
@@ -99,6 +99,7 @@ import PageHeader from '@/components/layout/PageHeader.vue';
 import { AppStateView, PullToRefresh } from '@/capabilities/design-system/public';
 import { digestService } from '@/services/DigestService';
 import { studyService, type StudyDashboard, type StudyPoint } from '@/services/StudyService';
+import { essayCenterLocation } from '@/features/practice/EssayNavigation';
 
 const router = useRouter();
 const studyDashboard = ref<StudyDashboard | null>(null);
@@ -131,7 +132,7 @@ const learningItems = [
   { title: '考点精讲', description: '按知识点学习概念、边界和方法', icon: BookOpenIcon, tone: 'green', to: '/vue/study/lecture' },
   { title: '每日积累', description: '沉淀时政热点和公考知识', icon: LandmarkIcon, tone: 'blue', to: '/vue/digest' },
   { title: '知识地图', description: '按大纲查看知识结构和掌握情况', icon: MapIcon, tone: 'purple', to: '/vue/knowledge-graph' },
-  { title: '申论学习', description: '学习材料阅读、题型方法和表达结构', icon: FileTextIcon, tone: 'orange', to: '/vue/essay' }
+  { title: '申论学习', description: '学习材料阅读、题型方法和表达结构', icon: FileTextIcon, tone: 'orange', to: essayCenterLocation('tutor') }
 ];
 
 const practiceItems = [


### PR DESCRIPTION
## Summary

- give every essay set a stable identity and explicit purpose
- isolate tutor, self-practice, true-question, and mock-exam histories and generation scopes
- harden detail routing, timer ownership, task navigation, and repository contracts
- remove history N+1 reads and add paged mock-history lookup

## Verification

- `npm run typecheck`
- `npm run check:code-quality`
- `npm run check:architecture`
- `npm run check:essay-question-sets`
- full `npm run build` passed before the final purpose-preservation and deduplication patch; targeted gates passed after it

Closes #18