### PR TITLE
Fix indexed essay question-set classification and history

### DIFF
--- a/scripts/verify-essay-question-set-classification.mjs
+++ b/scripts/verify-essay-question-set-classification.mjs
@@ -13,18 +13,20 @@ const server = await createServer({
 });
 
 try {
-  const [identity, navigation, tasks, featureModule, repositoryModule] = await Promise.all([
+  const [identity, navigation, tasks, featureModule, repositoryModule, indexedRepositoryModule] = await Promise.all([
     server.ssrLoadModule('/src/domain/essayQuestionSet.ts'),
     server.ssrLoadModule('/src/features/practice/EssayNavigation.ts'),
     server.ssrLoadModule('/src/services/GenerationTaskContract.ts'),
     server.ssrLoadModule('/src/features/practice/EssayPracticeCenterFeature.ts'),
-    server.ssrLoadModule('/src/services/EssayRepository.ts')
+    server.ssrLoadModule('/src/services/EssayRepository.ts'),
+    server.ssrLoadModule('/src/modules/content/adapters/IndexedDbLearningAssetRepository.ts')
   ]);
 
   verifyIdentityAndTaskScope(identity, tasks);
   verifyNavigation(navigation);
   await verifyClassificationAndOrdering(featureModule, identity);
   await verifyHistorySummaryQuery(repositoryModule);
+  await verifyIndexedPurposeQuery(indexedRepositoryModule);
 
   console.log('Essay question-set classification verification passed.');
 } finally {
@@ -131,6 +133,8 @@ async function verifyClassificationAndOrdering({ EssayPracticeCenterFeature }, {
   assert(sets.every((item) => item.context.questionSetId === item.key));
   assert.equal(isEssayMockContext(assets.at(-1).payload.essayContext), true);
   assert.equal(isEssayMockContext(assets[0].payload.essayContext), false);
+  assert.deepEqual(runtime.queries[0].purposes, ['practice', 'true_question']);
+  assert.equal(runtime.queries[0].latestPerBusinessKey, true);
 }
 
 async function verifyHistorySummaryQuery({ EssayRepository }) {
@@ -145,10 +149,39 @@ async function verifyHistorySummaryQuery({ EssayRepository }) {
   assert.deepEqual(history.map((item) => item.key), ['EssayQuestionSetId:2', 'EssayQuestionSetId:1']);
   assert(history.every((item) => 'question' in item && 'updatedAt' in item && !('state' in item)));
   assert.deepEqual(counters, { cycle: 1, list: 1, findLatest: 0 }, 'history summaries must not load every set detail');
+  assert.deepEqual(runtime.queries[0].purposes, ['practice', 'true_question']);
+  assert.equal(runtime.queries[0].latestPerBusinessKey, true);
+}
+
+async function verifyIndexedPurposeQuery({ IndexedDbLearningAssetRepository }) {
+  const calls = { indexed: 0, full: 0 };
+  const database = {
+    getAllByIndex: async (_store, index, key) => {
+      calls.indexed += 1;
+      assert.equal(index, 'by_cycle_kind_purpose_status');
+      return [asset(`EssayQuestionSetId:${key[2]}`, key[2] === 'true_question' ? 'true' : 'self', String(key[2]), 100, key[2])];
+    },
+    getAll: async () => {
+      calls.full += 1;
+      return [];
+    }
+  };
+  const repository = new IndexedDbLearningAssetRepository(database, {});
+  const result = await repository.list({
+    examCycleId: 'ExamCycleId:test',
+    kinds: ['essay_question'],
+    purposes: ['practice', 'true_question'],
+    status: 'ready',
+    latestPerBusinessKey: true,
+    limit: 20
+  });
+  assert.equal(result.length, 2);
+  assert.deepEqual(calls, { indexed: 2, full: 0 }, 'purpose history must use the compound index instead of loading the full asset table');
 }
 
 function runtimeWithAssets(assets, counters = { cycle: 0, list: 0, findLatest: 0 }) {
-  return {
+  const runtime = {
+    queries: [],
     candidateRepository: {
       findCurrentCycle: async () => {
         counters.cycle += 1;
@@ -156,16 +189,29 @@ function runtimeWithAssets(assets, counters = { cycle: 0, list: 0, findLatest: 0
       }
     },
     learningAssetStore: {
-      list: async () => {
+      list: async (query) => {
         counters.list += 1;
-        return assets;
+        runtime.queries.push(query);
+        const filtered = assets
+          .filter((item) => !query.kinds?.length || query.kinds.includes(item.kind))
+          .filter((item) => !query.status || item.status === query.status)
+          .filter((item) => !query.purposes?.length || query.purposes.includes(item.purpose))
+          .sort((left, right) => right.updatedAt - left.updatedAt);
+        const latest = new Map();
+        filtered.forEach((item) => {
+          if (!latest.has(item.businessKey)) latest.set(item.businessKey, item);
+        });
+        const deduped = query.latestPerBusinessKey ? [...latest.values()] : filtered;
+        return deduped.slice(query.offset || 0, (query.offset || 0) + query.limit);
       },
+      count: async (query) => (await runtime.learningAssetStore.list({ ...query, limit: 500 })).length,
       findLatest: async () => {
         counters.findLatest += 1;
         return undefined;
       }
     }
   };
+  return runtime;
 }
 
 function asset(businessKey, entryMode, title, updatedAt, purpose = entryMode === 'true' ? 'true_question' : 'practice') {
@@ -176,6 +222,7 @@ function asset(businessKey, entryMode, title, updatedAt, purpose = entryMode ===
     businessKey,
     title,
     status: 'ready',
+    purpose,
     payload: {
       essayContext: { date: '2026-08-12', topic: '归纳概括', type: 'short', entryMode, purpose },
       question: { id: `question:${title}`, title, material: '材料', requirement: '要求' }

--- a/scripts/verify-essay-question-set-classification.mjs
+++ b/scripts/verify-essay-question-set-classification.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
 import { createServer } from '../web/node_modules/vite/dist/node/index.js';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../web');
@@ -13,13 +14,28 @@ const server = await createServer({
 });
 
 try {
-  const [identity, navigation, tasks, featureModule, repositoryModule, indexedRepositoryModule] = await Promise.all([
+  const [
+    identity,
+    navigation,
+    tasks,
+    featureModule,
+    repositoryModule,
+    indexedRepositoryModule,
+    sqliteRepositoryModule,
+    answerModule,
+    questionTextModule,
+    autosaveModule
+  ] = await Promise.all([
     server.ssrLoadModule('/src/domain/essayQuestionSet.ts'),
     server.ssrLoadModule('/src/features/practice/EssayNavigation.ts'),
     server.ssrLoadModule('/src/services/GenerationTaskContract.ts'),
     server.ssrLoadModule('/src/features/practice/EssayPracticeCenterFeature.ts'),
     server.ssrLoadModule('/src/services/EssayRepository.ts'),
-    server.ssrLoadModule('/src/modules/content/adapters/IndexedDbLearningAssetRepository.ts')
+    server.ssrLoadModule('/src/modules/content/adapters/IndexedDbLearningAssetRepository.ts'),
+    server.ssrLoadModule('/src/modules/content/adapters/SqliteLearningAssetRepository.ts'),
+    server.ssrLoadModule('/src/domain/essayAnswer.ts'),
+    server.ssrLoadModule('/src/domain/essayQuestionText.ts'),
+    server.ssrLoadModule('/src/services/EssayDraftAutosave.ts')
   ]);
 
   verifyIdentityAndTaskScope(identity, tasks);
@@ -27,10 +43,115 @@ try {
   await verifyClassificationAndOrdering(featureModule, identity);
   await verifyHistorySummaryQuery(repositoryModule);
   await verifyIndexedPurposeQuery(indexedRepositoryModule);
+  await verifyRepositoryContract(indexedRepositoryModule, sqliteRepositoryModule);
+  verifyAnswerPresentation(answerModule, questionTextModule);
+  await verifyDraftAutosave(autosaveModule);
 
   console.log('Essay question-set classification verification passed.');
 } finally {
   await server.close();
+}
+
+async function verifyDraftAutosave({ EssayDraftAutosave }) {
+  const writes = [];
+  const autosave = new EssayDraftAutosave(async (draft, context) => {
+    writes.push(`${context.questionSetId}:${draft}`);
+  }, 5);
+
+  autosave.schedule('一', { questionSetId: 'set-a' });
+  autosave.schedule('一二', { questionSetId: 'set-a' });
+  autosave.schedule('一二三', { questionSetId: 'set-a' });
+  await autosave.flush();
+  assert.deepEqual(writes, ['set-a:一二三'], 'keystrokes coalesce into a single write');
+
+  // Leaving a set must persist the pending keystrokes, not discard them.
+  autosave.schedule('未保存的作答', { questionSetId: 'set-a' });
+  await autosave.flush();
+  assert.deepEqual(
+    writes.at(-1),
+    'set-a:未保存的作答',
+    'switching away from a set must flush its pending draft'
+  );
+
+  autosave.schedule('丢弃我', { questionSetId: 'set-a' });
+  autosave.cancel();
+  await autosave.flush();
+  assert.equal(writes.length, 2, 'an explicitly cancelled draft is never written');
+
+  const ordered = [];
+  const serial = new EssayDraftAutosave(async (draft) => {
+    await new Promise((resolve) => setTimeout(resolve, draft === 'slow' ? 20 : 0));
+    ordered.push(draft);
+  }, 0);
+  serial.schedule('slow', { questionSetId: 'set-b' });
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  serial.schedule('fast', { questionSetId: 'set-b' });
+  await serial.flush();
+  assert.deepEqual(ordered, ['slow', 'fast'], 'writes stay ordered so the last keystroke wins');
+
+  const failures = [];
+  const failing = new EssayDraftAutosave(
+    async (draft) => { if (draft === 'boom') throw new Error('write failed'); failures.push(draft); },
+    0,
+    (cause) => failures.push(`caught:${cause.message}`)
+  );
+  failing.schedule('boom', { questionSetId: 'set-c' });
+  await failing.flush();
+  failing.schedule('after', { questionSetId: 'set-c' });
+  await failing.flush();
+  assert.deepEqual(failures, ['caught:write failed', 'after'], 'a failed write must not poison later ones');
+}
+
+function verifyAnswerPresentation(
+  { countEssayWords, parseEssayWordLimit, describeEssayWordCount },
+  { splitEssayMaterial, splitEssayRequirement }
+) {
+  assert.equal(countEssayWords('概括 主要\n问题。'), 7, 'whitespace never counts toward a 申论 word count');
+
+  assert.deepEqual(parseEssayWordLimit('不超过300字'), { max: 300 });
+  assert.deepEqual(parseEssayWordLimit('字数200字以内'), { max: 200 });
+  assert.deepEqual(parseEssayWordLimit('不少于150字'), { min: 150 });
+  assert.deepEqual(parseEssayWordLimit('200-300字'), { min: 200, max: 300 });
+  assert.deepEqual(parseEssayWordLimit('500字左右'), { min: 450, max: 550 });
+  assert.deepEqual(parseEssayWordLimit('概括主要内容。'), {}, 'a requirement without a 字数 rule must not invent one');
+  assert.deepEqual(
+    parseEssayWordLimit('(1) 不超过200字；(2) 不超过300字'),
+    { max: 500 },
+    'one answer sheet holds every task, so per-task budgets add up'
+  );
+
+  const withinLimit = describeEssayWordCount('一'.repeat(120), '不超过300字');
+  assert.equal(withinLimit.tone, 'neutral');
+  assert.equal(withinLimit.label, '120 / 300 字');
+  const overLimit = describeEssayWordCount('一'.repeat(320), '不超过300字');
+  assert.equal(overLimit.tone, 'danger');
+  assert.match(overLimit.label, /超出 20 字/);
+  assert.equal(describeEssayWordCount('一'.repeat(80), '不少于150字').tone, 'warning');
+  assert.equal(describeEssayWordCount('', '不少于150字').tone, 'neutral', 'an untouched answer is not yet too short');
+
+  assert.deepEqual(
+    splitEssayMaterial('给定资料：材料一：甲。资料二：乙。'),
+    ['材料一：甲。', '资料二：乙。']
+  );
+  assert.deepEqual(splitEssayMaterial('   '), []);
+  assert.deepEqual(
+    splitEssayRequirement('要求：(1) 全面准确；(2) 条理清晰'),
+    ['全面准确；', '条理清晰']
+  );
+  assert.deepEqual(
+    splitEssayRequirement('概括主要问题，不超过300字。'),
+    ['概括主要问题，不超过300字。'],
+    'a single-task requirement stays whole'
+  );
+  assert.deepEqual(
+    splitEssayRequirement('概括 主要 问题，不超过300字。'),
+    ['概括 主要 问题，不超过300字。'],
+    'spaces inside a task must never be treated as task boundaries'
+  );
+  assert.deepEqual(
+    splitEssayRequirement('一、概括问题。二、提出对策。'),
+    ['概括问题。', '提出对策。']
+  );
 }
 
 function verifyIdentityAndTaskScope(identity, tasks) {
@@ -115,25 +236,28 @@ async function verifyClassificationAndOrdering({ EssayPracticeCenterFeature }, {
     asset('EssayQuestionSetId:self-2', 'self', '自主题二', 400),
     asset('EssayQuestionSetId:self-1', 'self', '自主题一', 300),
     asset('EssayQuestionSetId:true-1', 'true', '真题一', 200),
+    asset('EssayQuestionSetId:legacy-1', 'self', '旧版未分类题', 250, 'legacy_unknown'),
     asset('EssayQuestionSetId:tutor-1', 'tutor', '私教题旧版本', 50),
     asset('EssayQuestionSetId:mock-1', 'self', '申论模考', 500, 'mock')
   ];
   const runtime = runtimeWithAssets(assets);
   const sets = await new EssayPracticeCenterFeature(runtime).listSets();
-  assert.equal(sets.length, 4);
+  assert.equal(sets.length, 5);
   assert.deepEqual(sets.map((item) => item.key), [
     'EssayQuestionSetId:self-2',
     'EssayQuestionSetId:self-1',
+    'EssayQuestionSetId:legacy-1',
     'EssayQuestionSetId:true-1',
     'EssayQuestionSetId:tutor-1'
   ]);
   assert.equal(sets.filter((item) => item.context.entryMode === 'tutor').length, 1);
-  assert.equal(sets.filter((item) => item.context.entryMode === 'self').length, 2);
+  assert.equal(sets.filter((item) => item.context.entryMode === 'self' && item.classification !== 'legacy_unknown').length, 2);
   assert.equal(sets.filter((item) => item.context.entryMode === 'true').length, 1);
+  assert.equal(sets.find((item) => item.key === 'EssayQuestionSetId:legacy-1').classification, 'legacy_unknown');
   assert(sets.every((item) => item.context.questionSetId === item.key));
   assert.equal(isEssayMockContext(assets.at(-1).payload.essayContext), true);
   assert.equal(isEssayMockContext(assets[0].payload.essayContext), false);
-  assert.deepEqual(runtime.queries[0].purposes, ['practice', 'true_question']);
+  assert.deepEqual(runtime.queries[0].purposes, ['practice', 'true_question', 'legacy_unknown']);
   assert.equal(runtime.queries[0].latestPerBusinessKey, true);
 }
 
@@ -141,15 +265,17 @@ async function verifyHistorySummaryQuery({ EssayRepository }) {
   const counters = { cycle: 0, list: 0, findLatest: 0 };
   const assets = [
     asset('EssayQuestionSetId:2', 'self', '新题', 200),
+    asset('EssayQuestionSetId:legacy', 'self', '旧版未分类题', 150, 'legacy_unknown'),
     asset('EssayQuestionSetId:1', 'tutor', '旧题', 100)
   ];
   const runtime = runtimeWithAssets(assets, counters);
   const repository = new EssayRepository(async () => runtime);
   const history = await repository.listStates();
-  assert.deepEqual(history.map((item) => item.key), ['EssayQuestionSetId:2', 'EssayQuestionSetId:1']);
+  assert.deepEqual(history.map((item) => item.key), ['EssayQuestionSetId:2', 'EssayQuestionSetId:legacy', 'EssayQuestionSetId:1']);
+  assert.equal(history[1].classification, 'legacy_unknown');
   assert(history.every((item) => 'question' in item && 'updatedAt' in item && !('state' in item)));
   assert.deepEqual(counters, { cycle: 1, list: 1, findLatest: 0 }, 'history summaries must not load every set detail');
-  assert.deepEqual(runtime.queries[0].purposes, ['practice', 'true_question']);
+  assert.deepEqual(runtime.queries[0].purposes, ['practice', 'true_question', 'legacy_unknown']);
   assert.equal(runtime.queries[0].latestPerBusinessKey, true);
 }
 
@@ -177,6 +303,88 @@ async function verifyIndexedPurposeQuery({ IndexedDbLearningAssetRepository }) {
   });
   assert.equal(result.length, 2);
   assert.deepEqual(calls, { indexed: 2, full: 0 }, 'purpose history must use the compound index instead of loading the full asset table');
+}
+
+async function verifyRepositoryContract({ IndexedDbLearningAssetRepository }, { SqliteLearningAssetRepository }) {
+  const records = [
+    contractAsset('a-v1', 'set-a', 1, 300, 'practice', 'ready'),
+    contractAsset('a-v2', 'set-a', 2, 100, 'practice', 'ready'),
+    contractAsset('b-v1', 'set-b', 1, 400, 'practice', 'ready'),
+    contractAsset('b-v2', 'set-b', 2, 500, 'mock', 'ready'),
+    contractAsset('c-v1', 'set-c', 1, 200, 'practice', 'ready'),
+    contractAsset('c-v2', 'set-c', 2, 600, 'practice', 'retired')
+  ];
+  const indexedDatabase = {
+    getAllByIndex: async (_store, _index, key) => records.filter((item) => (
+      item.examCycleId === key[0] && item.kind === key[1] && item.purpose === key[2] && item.status === key[3]
+    )),
+    getAll: async () => records
+  };
+  const indexed = new IndexedDbLearningAssetRepository(indexedDatabase, {});
+
+  const native = new DatabaseSync(':memory:');
+  native.exec(`CREATE TABLE learning_assets(
+    id TEXT PRIMARY KEY,
+    exam_cycle_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    business_key TEXT NOT NULL,
+    title TEXT NOT NULL,
+    status TEXT NOT NULL,
+    purpose TEXT,
+    payload_json TEXT NOT NULL,
+    source_agent_run_id TEXT,
+    version INTEGER NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  )`);
+  const insert = native.prepare(`INSERT INTO learning_assets(
+    id,exam_cycle_id,kind,business_key,title,status,purpose,payload_json,source_agent_run_id,version,created_at,updated_at
+  ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`);
+  for (const item of records) insert.run(
+    item.id, item.examCycleId, item.kind, item.businessKey, item.title, item.status,
+    item.purpose, JSON.stringify(item.payload), null, item.version, item.createdAt, item.updatedAt
+  );
+  const sqlite = new SqliteLearningAssetRepository({
+    query: async (sql, parameters = []) => native.prepare(sql).all(...parameters)
+  }, {});
+  const query = {
+    examCycleId: 'ExamCycleId:test',
+    kinds: ['essay_question'],
+    purposes: ['practice'],
+    status: 'ready',
+    latestPerBusinessKey: true,
+    limit: 20
+  };
+  const [indexedItems, sqliteItems, indexedCount, sqliteCount] = await Promise.all([
+    indexed.list(query),
+    sqlite.list(query),
+    indexed.count(query),
+    sqlite.count(query)
+  ]);
+  const expectedIds = ['b-v1', 'c-v1', 'a-v2'];
+  assert.deepEqual(indexedItems.map((item) => item.id), expectedIds);
+  assert.deepEqual(sqliteItems.map((item) => item.id), expectedIds);
+  assert.equal(indexedCount, 3);
+  assert.equal(sqliteCount, 3);
+  assert.deepEqual((await indexed.list({ ...query, offset: 1, limit: 1 })).map((item) => item.id), ['c-v1']);
+  assert.deepEqual((await sqlite.list({ ...query, offset: 1, limit: 1 })).map((item) => item.id), ['c-v1']);
+  native.close();
+}
+
+function contractAsset(id, businessKey, version, updatedAt, purpose, status) {
+  return {
+    id,
+    examCycleId: 'ExamCycleId:test',
+    kind: 'essay_question',
+    businessKey,
+    title: id,
+    status,
+    purpose,
+    payload: {},
+    version,
+    createdAt: updatedAt,
+    updatedAt
+  };
 }
 
 function runtimeWithAssets(assets, counters = { cycle: 0, list: 0, findLatest: 0 }) {

--- a/web/src/capabilities/database/adapters/indexeddb/TutorIndexedDb.ts
+++ b/web/src/capabilities/database/adapters/indexeddb/TutorIndexedDb.ts
@@ -239,7 +239,14 @@ export class TutorIndexedDb {
   private openDatabase(): Promise<void> {
     if (!globalThis.indexedDB) return Promise.reject(new Error('IndexedDB is not available in this environment'));
     return new Promise((resolve, reject) => {
+      let upgradeError: Error | undefined;
       const request = globalThis.indexedDB.open(TUTOR_INDEXEDDB_NAME, TUTOR_INDEXEDDB_VERSION);
+      const failUpgrade = (stage: string, cause: unknown) => {
+        if (upgradeError) return;
+        const detail = cause instanceof Error ? cause.message : String(cause || 'unknown error');
+        upgradeError = new Error(`Tutor IndexedDB upgrade failed during ${stage}: ${detail}`);
+        request.transaction?.abort();
+      };
       request.onupgradeneeded = (event) => {
         const database = request.result;
         if (!database.objectStoreNames.contains(TutorIndexedDbStore.CandidateCycleBundles)) {
@@ -350,7 +357,7 @@ export class TutorIndexedDb {
           );
         }
         if (event.oldVersion < 31 && learningAssetStore) {
-          migrateLearningAssetPurposes(learningAssetStore, agentRunStore);
+          migrateLearningAssetPurposes(learningAssetStore, agentRunStore, failUpgrade);
         }
         if (!database.objectStoreNames.contains(TutorIndexedDbStore.QuestionSources)) {
           const sourceStore = database.createObjectStore(TutorIndexedDbStore.QuestionSources, { keyPath: 'id' });
@@ -442,7 +449,7 @@ export class TutorIndexedDb {
         this.database.onversionchange = () => this.close();
         resolve();
       };
-      request.onerror = () => reject(request.error ?? new Error('Tutor IndexedDB failed to open'));
+      request.onerror = () => reject(upgradeError ?? request.error ?? new Error('Tutor IndexedDB failed to open'));
       request.onblocked = () => reject(new Error('Tutor IndexedDB upgrade is blocked by another tab'));
     });
   }
@@ -453,47 +460,65 @@ export class TutorIndexedDb {
   }
 }
 
-function migrateLearningAssetPurposes(store: IDBObjectStore, agentRunStore?: IDBObjectStore): void {
-  if (!agentRunStore) {
-    migrateLearningAssetPurposeRecords(store, new Map());
-    return;
-  }
-  const runRequest = agentRunStore.getAll();
-  runRequest.onsuccess = () => {
-    const sourceByRunId = new Map<string, string>();
-    for (const raw of runRequest.result as Array<Record<string, unknown>>) {
-      const run = objectValue(raw.run);
-      const snapshot = objectValue(run.inputSnapshot);
-      if (typeof run.id === 'string' && typeof snapshot.sourceId === 'string') {
-        sourceByRunId.set(run.id, snapshot.sourceId);
-      }
-    }
-    migrateLearningAssetPurposeRecords(store, sourceByRunId);
-  };
-}
-
-function migrateLearningAssetPurposeRecords(store: IDBObjectStore, sourceByRunId: ReadonlyMap<string, string>): void {
+function migrateLearningAssetPurposes(
+  store: IDBObjectStore,
+  agentRunStore: IDBObjectStore | undefined,
+  onError: (stage: string, cause: unknown) => void
+): void {
   const request = store.openCursor();
+  request.onerror = () => onError('learning asset cursor', request.error);
   request.onsuccess = () => {
     const cursor = request.result;
     if (!cursor) return;
     const asset = cursor.value as Record<string, unknown>;
-    if (asset.kind === 'essay_question' && !asset.purpose) {
-      const payload = objectValue(asset.payload);
-      const context = objectValue(payload.essayContext);
-      const sourceId = typeof asset.sourceAgentRunId === 'string'
-        ? sourceByRunId.get(asset.sourceAgentRunId)
-        : undefined;
-      cursor.update({ ...asset, purpose: inferLegacyEssayPurpose(context, sourceId) });
+    if (asset.kind !== 'essay_question' || asset.purpose) {
+      cursor.continue();
+      return;
     }
-    cursor.continue();
+    const payload = objectValue(asset.payload);
+    const context = objectValue(payload.essayContext);
+    const sourceAgentRunId = typeof asset.sourceAgentRunId === 'string' ? asset.sourceAgentRunId : undefined;
+    if (!agentRunStore || !sourceAgentRunId || purposeFromContext(context)) {
+      updateLegacyPurpose(cursor, asset, inferLegacyEssayPurpose(context), onError);
+      return;
+    }
+    const runRequest = agentRunStore.get(sourceAgentRunId);
+    runRequest.onerror = () => onError(`Agent run lookup for ${sourceAgentRunId}`, runRequest.error);
+    runRequest.onsuccess = () => {
+      const sourceId = sourceIdFromAgentRun(runRequest.result);
+      updateLegacyPurpose(cursor, asset, inferLegacyEssayPurpose(context, sourceId), onError);
+    };
   };
 }
 
-function inferLegacyEssayPurpose(context: Record<string, unknown>, sourceId?: string): string {
+function updateLegacyPurpose(
+  cursor: IDBCursorWithValue,
+  asset: Record<string, unknown>,
+  purpose: string,
+  onError: (stage: string, cause: unknown) => void
+): void {
+  const updateRequest = cursor.update({ ...asset, purpose });
+  updateRequest.onerror = () => onError(`learning asset update for ${String(asset.id || cursor.primaryKey)}`, updateRequest.error);
+  updateRequest.onsuccess = () => cursor.continue();
+}
+
+function sourceIdFromAgentRun(value: unknown): string | undefined {
+  const aggregate = objectValue(value);
+  const run = objectValue(aggregate.run);
+  const snapshot = objectValue(run.inputSnapshot);
+  return typeof snapshot.sourceId === 'string' ? snapshot.sourceId : undefined;
+}
+
+function purposeFromContext(context: Record<string, unknown>): string | undefined {
   if (context.purpose === 'mock') return 'mock';
   if (context.purpose === 'true_question' || context.entryMode === 'true') return 'true_question';
   if (context.purpose === 'practice' || context.entryMode === 'tutor') return 'practice';
+  return undefined;
+}
+
+function inferLegacyEssayPurpose(context: Record<string, unknown>, sourceId?: string): string {
+  const explicitPurpose = purposeFromContext(context);
+  if (explicitPurpose) return explicitPurpose;
   if (sourceId?.startsWith('mock:申论:')) return 'mock';
   if (sourceId?.startsWith('essay:')) return 'practice';
   return 'legacy_unknown';

--- a/web/src/capabilities/database/adapters/indexeddb/TutorIndexedDb.ts
+++ b/web/src/capabilities/database/adapters/indexeddb/TutorIndexedDb.ts
@@ -1,7 +1,7 @@
 import { TUTOR_DATABASE_NAME } from '../../config/TutorDatabaseConfig';
 
 export const TUTOR_INDEXEDDB_NAME = `${TUTOR_DATABASE_NAME}-web`;
-export const TUTOR_INDEXEDDB_VERSION = 30;
+export const TUTOR_INDEXEDDB_VERSION = 31;
 
 export const TutorIndexedDbStore = {
   CandidateCycleBundles: 'candidate_cycle_bundles',
@@ -339,8 +339,18 @@ export class TutorIndexedDb {
         if (!database.objectStoreNames.contains(TutorIndexedDbStore.ProactiveSignals)) {
           database.createObjectStore(TutorIndexedDbStore.ProactiveSignals, { keyPath: 'id' });
         }
-        if (!database.objectStoreNames.contains(TutorIndexedDbStore.LearningAssets)) {
-          database.createObjectStore(TutorIndexedDbStore.LearningAssets, { keyPath: 'id' });
+        const learningAssetStore = database.objectStoreNames.contains(TutorIndexedDbStore.LearningAssets)
+          ? request.transaction?.objectStore(TutorIndexedDbStore.LearningAssets)
+          : database.createObjectStore(TutorIndexedDbStore.LearningAssets, { keyPath: 'id' });
+        if (learningAssetStore && !learningAssetStore.indexNames.contains('by_cycle_kind_purpose_status')) {
+          learningAssetStore.createIndex(
+            'by_cycle_kind_purpose_status',
+            ['examCycleId', 'kind', 'purpose', 'status'],
+            { unique: false }
+          );
+        }
+        if (event.oldVersion < 31 && learningAssetStore) {
+          migrateLearningAssetPurposes(learningAssetStore, agentRunStore);
         }
         if (!database.objectStoreNames.contains(TutorIndexedDbStore.QuestionSources)) {
           const sourceStore = database.createObjectStore(TutorIndexedDbStore.QuestionSources, { keyPath: 'id' });
@@ -441,4 +451,56 @@ export class TutorIndexedDb {
     if (!this.database) throw new Error('Tutor IndexedDB is not open');
     return this.database;
   }
+}
+
+function migrateLearningAssetPurposes(store: IDBObjectStore, agentRunStore?: IDBObjectStore): void {
+  if (!agentRunStore) {
+    migrateLearningAssetPurposeRecords(store, new Map());
+    return;
+  }
+  const runRequest = agentRunStore.getAll();
+  runRequest.onsuccess = () => {
+    const sourceByRunId = new Map<string, string>();
+    for (const raw of runRequest.result as Array<Record<string, unknown>>) {
+      const run = objectValue(raw.run);
+      const snapshot = objectValue(run.inputSnapshot);
+      if (typeof run.id === 'string' && typeof snapshot.sourceId === 'string') {
+        sourceByRunId.set(run.id, snapshot.sourceId);
+      }
+    }
+    migrateLearningAssetPurposeRecords(store, sourceByRunId);
+  };
+}
+
+function migrateLearningAssetPurposeRecords(store: IDBObjectStore, sourceByRunId: ReadonlyMap<string, string>): void {
+  const request = store.openCursor();
+  request.onsuccess = () => {
+    const cursor = request.result;
+    if (!cursor) return;
+    const asset = cursor.value as Record<string, unknown>;
+    if (asset.kind === 'essay_question' && !asset.purpose) {
+      const payload = objectValue(asset.payload);
+      const context = objectValue(payload.essayContext);
+      const sourceId = typeof asset.sourceAgentRunId === 'string'
+        ? sourceByRunId.get(asset.sourceAgentRunId)
+        : undefined;
+      cursor.update({ ...asset, purpose: inferLegacyEssayPurpose(context, sourceId) });
+    }
+    cursor.continue();
+  };
+}
+
+function inferLegacyEssayPurpose(context: Record<string, unknown>, sourceId?: string): string {
+  if (context.purpose === 'mock') return 'mock';
+  if (context.purpose === 'true_question' || context.entryMode === 'true') return 'true_question';
+  if (context.purpose === 'practice' || context.entryMode === 'tutor') return 'practice';
+  if (sourceId?.startsWith('mock:申论:')) return 'mock';
+  if (sourceId?.startsWith('essay:')) return 'practice';
+  return 'legacy_unknown';
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
 }

--- a/web/src/capabilities/database/migrations/037_learning_asset_purpose.sql
+++ b/web/src/capabilities/database/migrations/037_learning_asset_purpose.sql
@@ -1,0 +1,26 @@
+ALTER TABLE learning_assets ADD COLUMN purpose TEXT
+  CHECK(purpose IS NULL OR purpose IN ('practice','mock','true_question','legacy_unknown'));
+
+UPDATE learning_assets
+SET purpose = CASE
+  WHEN json_extract(payload_json, '$.essayContext.purpose') = 'mock' THEN 'mock'
+  WHEN json_extract(payload_json, '$.essayContext.purpose') = 'true_question'
+    OR json_extract(payload_json, '$.essayContext.entryMode') = 'true' THEN 'true_question'
+  WHEN json_extract(payload_json, '$.essayContext.purpose') = 'practice'
+    OR json_extract(payload_json, '$.essayContext.entryMode') = 'tutor' THEN 'practice'
+  WHEN EXISTS(
+    SELECT 1 FROM tutor_agent_runs run
+    WHERE run.id = learning_assets.source_agent_run_id
+      AND json_extract(run.input_snapshot_json, '$.sourceId') LIKE 'mock:申论:%'
+  ) THEN 'mock'
+  WHEN EXISTS(
+    SELECT 1 FROM tutor_agent_runs run
+    WHERE run.id = learning_assets.source_agent_run_id
+      AND json_extract(run.input_snapshot_json, '$.sourceId') LIKE 'essay:%'
+  ) THEN 'practice'
+  ELSE 'legacy_unknown'
+END
+WHERE kind = 'essay_question' AND purpose IS NULL;
+
+CREATE INDEX learning_assets_purpose_timeline_idx
+  ON learning_assets(exam_cycle_id,kind,purpose,status,updated_at DESC,version DESC,id DESC);

--- a/web/src/capabilities/database/migrations/tutorMigrations.ts
+++ b/web/src/capabilities/database/migrations/tutorMigrations.ts
@@ -34,6 +34,7 @@ import agentRunHierarchySql from './033_agent_run_hierarchy.sql?raw';
 import generationSpecAgentRunSourceSql from './034_generation_spec_agent_run_source.sql?raw';
 import adaptiveDailyPlanningSql from './035_adaptive_daily_planning.sql?raw';
 import learningDataMaintenanceSql from './036_learning_data_maintenance.sql?raw';
+import learningAssetPurposeSql from './037_learning_asset_purpose.sql?raw';
 import type { Migration } from './Migration';
 
 export const tutorMigrations: readonly Migration[] = [
@@ -252,5 +253,11 @@ export const tutorMigrations: readonly Migration[] = [
     name: 'learning_data_maintenance',
     checksum: 'sha256:6974418186477b633481ddec377a71f1973c135057680e2a000a364740133e5d',
     sql: learningDataMaintenanceSql
+  },
+  {
+    version: 37,
+    name: 'learning_asset_purpose',
+    checksum: 'sha256:f0f196b17c06cdcb54e998e015be5ba2f173700e00eb4a36996898a75318a319',
+    sql: learningAssetPurposeSql
   }
 ];

--- a/web/src/composition-root/agent/BusinessAgentContracts.ts
+++ b/web/src/composition-root/agent/BusinessAgentContracts.ts
@@ -1,5 +1,8 @@
 import type { JsonObject } from '@/kernel/public';
-import type { LearningAssetKind as LearningAssetKindCode } from '@/modules/content/public';
+import type {
+  LearningAssetKind as LearningAssetKindCode,
+  LearningAssetPurpose as LearningAssetPurposeCode
+} from '@/modules/content/public';
 import type { AITextMessage, AITextRequestOptions } from '../ai/ConfiguredAIClient';
 
 export type BusinessAgentTaskType =
@@ -61,6 +64,7 @@ export interface BusinessAgentExecutionContext {
     readonly businessKey: string;
     readonly title: string;
     readonly payload: Record<string, unknown>;
+    readonly purpose?: LearningAssetPurposeCode;
   }): Promise<{ readonly id: string; readonly version: number }>;
   findLatestLearningAsset(input: {
     readonly kind: LearningAssetKindCode;

--- a/web/src/composition-root/agent/BusinessAgentExecutors.ts
+++ b/web/src/composition-root/agent/BusinessAgentExecutors.ts
@@ -18,6 +18,7 @@ import {
   GenerationVariationKind,
   LearningAssetKind
 } from '@/modules/content/public';
+import { AgentRunInputIncompatibleError } from '@/modules/agent/public';
 import { completeFreshGeneratedContent, learningAssetReferences } from './FreshGeneratedContent';
 import type {
   BusinessAgentExecutionContext,
@@ -278,7 +279,9 @@ export const essayGradeExecutor: BusinessAgentExecutor = async (task, context) =
   const content = asString(task.payload?.content);
   if (!content.trim()) throw new Error('申论批改任务缺少作答内容');
   const questionSetId = asString(task.payload?.questionSetId).trim();
-  if (!questionSetId) throw new Error('申论批改任务缺少题组标识');
+  if (!questionSetId) {
+    throw new AgentRunInputIncompatibleError('该批改任务来自旧版本，缺少可靠的题组标识，已停止恢复。原作答数据不会被删除，请从对应题组重新提交批改。');
+  }
   const entryMode = normalizeEssayQuestionSetMode(task.payload?.entryMode);
   const essayContext = {
     questionSetId,
@@ -314,6 +317,7 @@ export const essayGradeExecutor: BusinessAgentExecutor = async (task, context) =
     kind: LearningAssetKind.EssayAttempt,
     businessKey: essayQuestionSetBusinessKey(essayContext),
     title: `${essayContext.topic}批改 · ${essayContext.date}`,
+    purpose: essayContext.purpose,
     payload: {
       questionAssetId: questionAsset.id,
       question,
@@ -543,6 +547,7 @@ export const mockExecutor: BusinessAgentExecutor = async (task, context) => {
       kind: LearningAssetKind.EssayQuestion,
       businessKey: essayQuestionSetBusinessKey({ questionSetId, date, topic: essayTopic, type: essayType, entryMode, purpose }),
       title: question.title,
+      purpose,
       payload: {
         question,
         essayContext: { questionSetId, date, topic: essayTopic, type: essayType, entryMode, purpose }

--- a/web/src/composition-root/agent/TaskMessageProjector.ts
+++ b/web/src/composition-root/agent/TaskMessageProjector.ts
@@ -136,6 +136,9 @@ function detail(run: AgentRunAggregate, fallback: string): string {
 }
 
 function taskErrorText(code: string, diagnostic?: string): string {
+  if (code === 'agent_run.input_incompatible') {
+    return diagnostic || '该任务来自旧版本，无法安全恢复，请在对应页面重新发起。';
+  }
   if (code === 'agent.AbortError' || code === 'generation.process_interrupted') {
     return '模型连接意外中断，请重新执行任务';
   }

--- a/web/src/composition-root/agent/createTutorAgentHandlers.ts
+++ b/web/src/composition-root/agent/createTutorAgentHandlers.ts
@@ -368,6 +368,7 @@ async function executeBusinessOperation(
         businessKey: input.businessKey,
         title: input.title,
         payload: toJsonObject(input.payload),
+        purpose: input.purpose,
         sourceAgentRunId: run.run.id
       });
       executionSignal.throwIfAborted();

--- a/web/src/composition-root/essay/EssayGradingCoordinator.ts
+++ b/web/src/composition-root/essay/EssayGradingCoordinator.ts
@@ -1,0 +1,24 @@
+import type { TutorDatabaseRuntime } from '../database/TutorDatabaseRuntime';
+import type { AgentRunView } from '@/modules/agent/public';
+
+/**
+ * Composition-root adapter that lets the essay detail page follow its own grading run.
+ * The view depends on this port only; it never reaches into the agent runtime.
+ */
+export class EssayGradingCoordinator {
+  constructor(private readonly runtime: TutorDatabaseRuntime) {}
+
+  async findActive(questionSetId: string): Promise<AgentRunView | undefined> {
+    if (!questionSetId) return undefined;
+    const tasks = await this.runtime.getAgentRunViews.execute({ limit: 50 });
+    return tasks.find((task) => isEssayGradingTask(task, questionSetId) && task.isActive);
+  }
+
+  async find(runId: string): Promise<AgentRunView | undefined> {
+    return this.runtime.getAgentRunViews.findById(runId as AgentRunView['id']);
+  }
+}
+
+function isEssayGradingTask(task: AgentRunView, questionSetId: string): boolean {
+  return task.intent === 'essayGrade' && task.actionParams.questionSetId === questionSetId;
+}

--- a/web/src/composition-root/public.ts
+++ b/web/src/composition-root/public.ts
@@ -14,6 +14,7 @@ export {
   type EssayContext,
   type EssayGenerationContext
 } from './essay/EssayGenerationCoordinator';
+export { EssayGradingCoordinator } from './essay/EssayGradingCoordinator';
 export {
   importAgentAttachment,
   importAgentAttachments,

--- a/web/src/domain/essayAnswer.ts
+++ b/web/src/domain/essayAnswer.ts
@@ -1,0 +1,82 @@
+export interface EssayWordLimit {
+  readonly min?: number;
+  readonly max?: number;
+}
+
+export type EssayWordCountTone = 'neutral' | 'warning' | 'danger';
+
+export interface EssayWordCountStatus {
+  readonly count: number;
+  readonly limit: EssayWordLimit;
+  readonly label: string;
+  readonly tone: EssayWordCountTone;
+}
+
+/**
+ * Matches every字数 constraint a 申论 requirement can state, in one pass so a single
+ * number span is never counted twice (a `200-300字` range must not also read as `300字`).
+ */
+const WORD_LIMIT_PATTERN = new RegExp([
+  '(\\d{2,5})\\s*[-~—–至到]\\s*(\\d{2,5})\\s*字',
+  '(?:不超过|不多于|至多|最多)\\s*(\\d{2,5})\\s*字',
+  '(\\d{2,5})\\s*字(?:以内|之内|以下)',
+  '(?:不少于|不低于|至少)\\s*(\\d{2,5})\\s*字',
+  '(\\d{2,5})\\s*字左右'
+].map((part) => `(?:${part})`).join('|'), 'gu');
+
+/** 申论 answers are graded on characters; whitespace and line breaks never count. */
+export function countEssayWords(content: string): number {
+  return content.replace(/\s+/gu, '').length;
+}
+
+/**
+ * One answer sheet holds every task of the set, so per-task budgets add up into the
+ * budget the writer actually has to respect.
+ */
+export function parseEssayWordLimit(requirement: string): EssayWordLimit {
+  let min = 0;
+  let max = 0;
+  for (const match of requirement.matchAll(WORD_LIMIT_PATTERN)) {
+    const [, rangeMin, rangeMax, atMost, within, atLeast, around] = match;
+    if (rangeMin && rangeMax) {
+      min += Number(rangeMin);
+      max += Number(rangeMax);
+      continue;
+    }
+    if (atMost || within) {
+      max += Number(atMost || within);
+      continue;
+    }
+    if (atLeast) {
+      min += Number(atLeast);
+      continue;
+    }
+    if (around) {
+      min += Math.round(Number(around) * 0.9);
+      max += Math.round(Number(around) * 1.1);
+    }
+  }
+  return {
+    ...(min > 0 ? { min } : {}),
+    ...(max > 0 ? { max } : {})
+  };
+}
+
+export function describeEssayWordCount(content: string, requirement: string): EssayWordCountStatus {
+  const count = countEssayWords(content);
+  const limit = parseEssayWordLimit(requirement);
+  return { count, limit, label: limitLabel(count, limit), tone: limitTone(count, limit) };
+}
+
+function limitLabel(count: number, limit: EssayWordLimit): string {
+  if (limit.max && count > limit.max) return `${count} / ${limit.max} 字 · 超出 ${count - limit.max} 字`;
+  if (limit.max) return `${count} / ${limit.max} 字`;
+  if (limit.min) return `${count} 字 · 不少于 ${limit.min} 字`;
+  return `${count} 字`;
+}
+
+function limitTone(count: number, limit: EssayWordLimit): EssayWordCountTone {
+  if (limit.max && count > limit.max) return 'danger';
+  if (limit.min && count > 0 && count < limit.min) return 'warning';
+  return 'neutral';
+}

--- a/web/src/domain/essayQuestionText.ts
+++ b/web/src/domain/essayQuestionText.ts
@@ -1,0 +1,36 @@
+const MATERIAL_PREFIX = /^给定资料[:：]\s*/u;
+const MATERIAL_SPLIT = /\n{2,}|(?=材料[一二三四五六七八九十\d]+[:：])|(?=资料[一二三四五六七八九十\d]+[:：])/u;
+const REQUIREMENT_PREFIX = /^要求[:：]\s*/u;
+
+/**
+ * Task markers are consumed whole rather than matched by lookahead: an optional opening
+ * bracket makes a lookahead fire twice on `(1)`, once before the bracket and once before
+ * the digit, which strands the bracket as its own task.
+ */
+const TASK_MARKER = /(^|[\s；;。，,])\s*(?:[（(]\s*\d+\s*[）)]|\d+\s*[.、)]|[一二三四五六七八九十]+\s*[、.．])\s*/gu;
+/** Generated requirement text never carries a control character, so splitting on one is safe. */
+const TASK_SEPARATOR = '\u0000';
+
+/** Splits 给定资料 into the paragraphs a reader scans one at a time. */
+export function splitEssayMaterial(material: string): string[] {
+  const clean = material.trim();
+  if (!clean) return [];
+  return clean
+    .replace(MATERIAL_PREFIX, '')
+    .split(MATERIAL_SPLIT)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+/** Splits 作答要求 into individual tasks, keeping a single-task requirement whole. */
+export function splitEssayRequirement(requirement: string): string[] {
+  const clean = requirement.trim().replace(REQUIREMENT_PREFIX, '');
+  if (!clean) return [];
+  const parts = clean
+    .replace(TASK_MARKER, (_match, lead: string) => `${lead}${TASK_SEPARATOR}`)
+    .replace(/\n+/gu, TASK_SEPARATOR)
+    .split(TASK_SEPARATOR)
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return parts.length ? parts : [clean];
+}

--- a/web/src/features/exam/ExamHistoryPresentation.ts
+++ b/web/src/features/exam/ExamHistoryPresentation.ts
@@ -1,0 +1,22 @@
+export interface ExamHistoryGroup<Item> {
+  readonly month: string;
+  readonly label: string;
+  readonly items: readonly Item[];
+}
+
+export function durationText(durationMs?: number): string {
+  return durationMs ? `${Math.max(1, Math.round(durationMs / 60000))} 分钟` : '未记录时长';
+}
+
+export function groupHistoryByMonth<Item extends { readonly date: string }>(items: readonly Item[]): ExamHistoryGroup<Item>[] {
+  const grouped = new Map<string, Item[]>();
+  items.forEach((item) => {
+    const month = /^\d{4}-\d{2}/.test(item.date) ? item.date.slice(0, 7) : 'unknown';
+    grouped.set(month, [...(grouped.get(month) || []), item]);
+  });
+  return Array.from(grouped.entries()).map(([month, groupItems]) => ({
+    month,
+    label: month === 'unknown' ? '未记录月份' : `${month.slice(0, 4)}年${Number(month.slice(5))}月`,
+    items: groupItems
+  }));
+}

--- a/web/src/features/practice/EssayPracticeCenterFeature.ts
+++ b/web/src/features/practice/EssayPracticeCenterFeature.ts
@@ -25,6 +25,7 @@ export interface EssayPracticeContext {
 export interface EssayPracticeSet {
   readonly key: string;
   readonly updatedAt: number;
+  readonly classification: LearningAssetPurpose;
   readonly context: EssayPracticeContext;
   readonly question?: { readonly id: string; readonly title: string };
 }
@@ -68,7 +69,11 @@ export class EssayPracticeCenterFeature {
       examCycleId: cycle.examCycle.id,
       kinds: [LearningAssetKind.EssayQuestion],
       status: LearningAssetStatus.Ready,
-      purposes: [LearningAssetPurpose.Practice, LearningAssetPurpose.TrueQuestion],
+      purposes: [
+        LearningAssetPurpose.Practice,
+        LearningAssetPurpose.TrueQuestion,
+        LearningAssetPurpose.LegacyUnknown
+      ],
       latestPerBusinessKey: true,
       limit: 200
     });
@@ -76,6 +81,7 @@ export class EssayPracticeCenterFeature {
       .map((asset) => ({
         key: asset.businessKey,
         updatedAt: asset.updatedAt,
+        classification: asset.purpose ?? LearningAssetPurpose.LegacyUnknown,
         context: contextFromAsset(asset),
         question: questionFromAsset(asset)
       }))

--- a/web/src/features/practice/EssayPracticeCenterFeature.ts
+++ b/web/src/features/practice/EssayPracticeCenterFeature.ts
@@ -1,6 +1,7 @@
 import type { TutorDatabaseRuntime } from '@/composition-root/public';
 import {
   LearningAssetKind,
+  LearningAssetPurpose,
   LearningAssetStatus,
   type LearningAssetRecord
 } from '@/modules/content/public';
@@ -67,12 +68,11 @@ export class EssayPracticeCenterFeature {
       examCycleId: cycle.examCycle.id,
       kinds: [LearningAssetKind.EssayQuestion],
       status: LearningAssetStatus.Ready,
+      purposes: [LearningAssetPurpose.Practice, LearningAssetPurpose.TrueQuestion],
+      latestPerBusinessKey: true,
       limit: 200
     });
-    const latest = new Map<string, LearningAssetRecord>();
-    for (const asset of assets) if (!latest.has(asset.businessKey)) latest.set(asset.businessKey, asset);
-    return [...latest.values()]
-      .filter((asset) => contextFromAsset(asset).purpose !== 'mock')
+    return assets
       .map((asset) => ({
         key: asset.businessKey,
         updatedAt: asset.updatedAt,

--- a/web/src/features/practice/EssayPracticeCenterPanel.vue
+++ b/web/src/features/practice/EssayPracticeCenterPanel.vue
@@ -68,7 +68,7 @@
       <div class="essay-history">
         <button v-for="item in allStates" :key="item.key" type="button" @click="openSet(item)">
           <span>{{ item.question?.title || item.context.topic }}</span>
-          <em>{{ modeLabelFor(item.context.entryMode) }} · {{ item.context.date }}</em>
+            <em>{{ item.classification === 'legacy_unknown' ? '历史未分类' : modeLabelFor(item.context.entryMode) }} · {{ item.context.date }}</em>
         </button>
         <AppStateView v-if="!allStates.length" compact title="暂无历史题组" description="完成一次申论生成后会显示在这里。" />
       </div>
@@ -147,7 +147,10 @@ const modeCopy = computed(() => {
   if (props.modelValue === 'true') return { eyebrow: '真题校准', title: '用真实申论材料校准作答能力', description: '按年份、地区和题型练习真题，批改结果进入同一套能力证据链。' };
   return { eyebrow: '当前私教主线', title: '申论讲解、作答与复盘', description: '私教根据备考阶段、薄弱维度和剩余时间安排材料学习、作答训练与批改。' };
 });
-const modeStates = computed(() => allStates.value.filter((item) => normalizedMode(item.context.entryMode) === props.modelValue));
+const modeStates = computed(() => allStates.value.filter((item) => (
+  item.classification !== 'legacy_unknown'
+  && normalizedMode(item.context.entryMode) === props.modelValue
+)));
 const sets = computed(() => modeStates.value);
 const mainlineDescription = computed(() => props.modelValue === 'tutor' ? '根据今日计划和能力证据安排' : props.modelValue === 'self' ? '选择题型后生成独立题组' : '导入或整理真实申论材料后练习');
 const actionEyebrow = computed(() => props.modelValue === 'tutor' ? '今日教学动作' : props.modelValue === 'self' ? '自主出题' : '真题入口');

--- a/web/src/features/practice/useEssayGradingWatcher.ts
+++ b/web/src/features/practice/useEssayGradingWatcher.ts
@@ -31,13 +31,16 @@ export function useEssayGradingWatcher(options: EssayGradingWatcherOptions): Ess
   let timerId: number | null = null;
   let trackedRunId = '';
   let disposed = false;
+  let watchRevision = 0;
 
   function stop() {
+    watchRevision += 1;
     if (timerId !== null) window.clearInterval(timerId);
     timerId = null;
     trackedRunId = '';
     isGrading.value = false;
     progressText.value = '';
+    failure.value = '';
   }
 
   function adopt(run: AgentRunView) {
@@ -93,10 +96,11 @@ export function useEssayGradingWatcher(options: EssayGradingWatcherOptions): Ess
     failure: readonly(failure),
     track: adopt,
     async resume(questionSetId: string) {
+      const revision = watchRevision;
       try {
         const runtime = await initializeTutorRuntime();
         const run = await new EssayGradingCoordinator(runtime).findActive(questionSetId);
-        if (run) adopt(run);
+        if (run && revision === watchRevision && !disposed) adopt(run);
       } catch (cause) {
         // Failing to re-attach only costs the live progress banner, not the page.
         console.warn('[Essay] grading resume failed', cause);

--- a/web/src/features/practice/useEssayGradingWatcher.ts
+++ b/web/src/features/practice/useEssayGradingWatcher.ts
@@ -1,0 +1,107 @@
+import { onBeforeUnmount, readonly, ref, type Ref } from 'vue';
+import { EssayGradingCoordinator, initializeTutorRuntime } from '@/composition-root/public';
+import { AgentRunStatus, type AgentRunView } from '@/modules/agent/public';
+
+const POLL_INTERVAL_MS = 1_200;
+
+interface EssayGradingWatcherOptions {
+  /** Called once the grading run reaches a successful terminal state. */
+  readonly onGraded: () => Promise<void> | void;
+}
+
+export interface EssayGradingWatcher {
+  readonly isGrading: Readonly<Ref<boolean>>;
+  readonly progressText: Readonly<Ref<string>>;
+  readonly failure: Readonly<Ref<string>>;
+  /** Adopts a run that was just enqueued from this page. */
+  track(run: AgentRunView): void;
+  /** Re-attaches to a grading run that is still in flight from an earlier visit. */
+  resume(questionSetId: string): Promise<void>;
+  stop(): void;
+}
+
+/**
+ * Keeps the essay detail page in step with its background grading run, so feedback
+ * appears without the reader having to leave and come back.
+ */
+export function useEssayGradingWatcher(options: EssayGradingWatcherOptions): EssayGradingWatcher {
+  const isGrading = ref(false);
+  const progressText = ref('');
+  const failure = ref('');
+  let timerId: number | null = null;
+  let trackedRunId = '';
+  let disposed = false;
+
+  function stop() {
+    if (timerId !== null) window.clearInterval(timerId);
+    timerId = null;
+    trackedRunId = '';
+    isGrading.value = false;
+    progressText.value = '';
+  }
+
+  function adopt(run: AgentRunView) {
+    if (disposed) return;
+    failure.value = '';
+    if (!run.isActive) {
+      void settle(run);
+      return;
+    }
+    trackedRunId = String(run.id);
+    isGrading.value = true;
+    progressText.value = run.message || run.step || '批改任务已提交，正在等待执行';
+    if (timerId === null) timerId = window.setInterval(() => void poll(), POLL_INTERVAL_MS);
+  }
+
+  async function poll() {
+    if (!trackedRunId) return;
+    try {
+      const runtime = await initializeTutorRuntime();
+      const run = await new EssayGradingCoordinator(runtime).find(trackedRunId);
+      if (!run) return;
+      if (run.isActive) {
+        progressText.value = run.message || run.step || '正在批改';
+        return;
+      }
+      await settle(run);
+    } catch (cause) {
+      // A transient read failure must not kill the poll; the next tick tries again.
+      console.warn('[Essay] grading poll failed', cause);
+    }
+  }
+
+  async function settle(run: AgentRunView) {
+    const status = run.status;
+    stop();
+    if (status === AgentRunStatus.Completed) {
+      await options.onGraded();
+      return;
+    }
+    failure.value = status === AgentRunStatus.Cancelled
+      ? '批改任务已取消，可重新提交。'
+      : run.message || run.detail || '批改任务未完成，请重新提交。';
+  }
+
+  onBeforeUnmount(() => {
+    stop();
+    disposed = true;
+  });
+
+  return {
+    isGrading: readonly(isGrading),
+    progressText: readonly(progressText),
+    failure: readonly(failure),
+    track: adopt,
+    async resume(questionSetId: string) {
+      try {
+        const runtime = await initializeTutorRuntime();
+        const run = await new EssayGradingCoordinator(runtime).findActive(questionSetId);
+        if (run) adopt(run);
+      } catch (cause) {
+        // Failing to re-attach only costs the live progress banner, not the page.
+        console.warn('[Essay] grading resume failed', cause);
+      }
+    },
+    stop
+  };
+}

--- a/web/src/features/practice/useEssaySessionTimer.ts
+++ b/web/src/features/practice/useEssaySessionTimer.ts
@@ -1,0 +1,152 @@
+import { computed, onBeforeUnmount, onMounted, readonly, ref, type ComputedRef, type Ref } from 'vue';
+
+const TICK_MS = 1_000;
+const PERSIST_EVERY_TICKS = 10;
+
+interface StoredTimer {
+  readonly elapsedMs?: number;
+  readonly running?: boolean;
+  readonly savedAt?: number;
+}
+
+export interface EssaySessionTimer {
+  readonly elapsedText: ComputedRef<string>;
+  readonly isRunning: Readonly<Ref<boolean>>;
+  /** Hands the timer to a question set, persisting whatever the previous set had accrued. */
+  activate(questionSetId: string): void;
+  restore(): void;
+  start(): void;
+  /** Stops the clock and records that it is stopped, so a reload does not resume it. */
+  pause(): void;
+  toggle(): void;
+  /** Stops and clears the stored time, used when the set is deleted. */
+  clear(): void;
+}
+
+/**
+ * Owns the per-question-set stopwatch: its storage key, its interval and its
+ * background/foreground handling. The view only says which set is on screen.
+ */
+export function useEssaySessionTimer(): EssaySessionTimer {
+  const elapsedMs = ref(0);
+  const isRunning = ref(false);
+  let storageKey: string | null = null;
+  let timerId: number | null = null;
+  let ticksSincePersist = 0;
+  let disposed = false;
+
+  function persist() {
+    if (!storageKey) return;
+    try {
+      localStorage.setItem(storageKey, JSON.stringify({
+        elapsedMs: elapsedMs.value,
+        running: isRunning.value,
+        savedAt: Date.now()
+      }));
+    } catch {
+      // A full or blocked storage must never interrupt answering.
+    }
+  }
+
+  function stop() {
+    if (timerId !== null) window.clearInterval(timerId);
+    timerId = null;
+    isRunning.value = false;
+  }
+
+  function start() {
+    if (disposed || timerId !== null || !storageKey) return;
+    isRunning.value = true;
+    const startedAt = Date.now() - elapsedMs.value;
+    ticksSincePersist = 0;
+    timerId = window.setInterval(() => {
+      elapsedMs.value = Date.now() - startedAt;
+      ticksSincePersist += 1;
+      if (ticksSincePersist >= PERSIST_EVERY_TICKS) {
+        ticksSincePersist = 0;
+        persist();
+      }
+    }, TICK_MS);
+    persist();
+  }
+
+  function restore() {
+    if (!storageKey) return;
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (!raw) return;
+      const saved = JSON.parse(raw) as StoredTimer;
+      elapsedMs.value = saved.elapsedMs || 0;
+      if (saved.running && saved.savedAt) {
+        elapsedMs.value += Date.now() - saved.savedAt;
+        start();
+      }
+    } catch {
+      elapsedMs.value = 0;
+    }
+  }
+
+  /**
+   * Backgrounding must record the clock as still running so it resumes on return, which is
+   * why the stored `running` flag is written before the interval is torn down.
+   */
+  function handleVisibilityChange() {
+    if (document.hidden) {
+      persist();
+      stop();
+      return;
+    }
+    restore();
+  }
+
+  function pause() {
+    stop();
+    persist();
+  }
+
+  onMounted(() => document.addEventListener('visibilitychange', handleVisibilityChange));
+  onBeforeUnmount(() => {
+    document.removeEventListener('visibilitychange', handleVisibilityChange);
+    persist();
+    stop();
+    disposed = true;
+  });
+
+  return {
+    elapsedText: computed(() => formatDuration(elapsedMs.value)),
+    isRunning: readonly(isRunning),
+    activate(questionSetId: string) {
+      persist();
+      stop();
+      elapsedMs.value = 0;
+      storageKey = `essay-timer:${questionSetId}`;
+    },
+    restore,
+    start,
+    pause,
+    toggle() {
+      if (isRunning.value) {
+        pause();
+        return;
+      }
+      start();
+    },
+    clear() {
+      stop();
+      elapsedMs.value = 0;
+      try {
+        if (storageKey) localStorage.removeItem(storageKey);
+      } catch {
+        // ignore storage failures
+      }
+      // Releasing the key stops a later persist from resurrecting the deleted set's record.
+      storageKey = null;
+    }
+  };
+}
+
+function formatDuration(ms: number): string {
+  const seconds = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(seconds / 60);
+  return `${String(minutes).padStart(2, '0')}:${String(seconds % 60).padStart(2, '0')}`;
+}

--- a/web/src/features/practice/useEssaySessionTimer.ts
+++ b/web/src/features/practice/useEssaySessionTimer.ts
@@ -5,8 +5,6 @@ const PERSIST_EVERY_TICKS = 10;
 
 interface StoredTimer {
   readonly elapsedMs?: number;
-  readonly running?: boolean;
-  readonly savedAt?: number;
 }
 
 export interface EssaySessionTimer {
@@ -34,14 +32,13 @@ export function useEssaySessionTimer(): EssaySessionTimer {
   let timerId: number | null = null;
   let ticksSincePersist = 0;
   let disposed = false;
+  let resumeAfterVisibility = false;
 
   function persist() {
     if (!storageKey) return;
     try {
       localStorage.setItem(storageKey, JSON.stringify({
-        elapsedMs: elapsedMs.value,
-        running: isRunning.value,
-        savedAt: Date.now()
+        elapsedMs: elapsedMs.value
       }));
     } catch {
       // A full or blocked storage must never interrupt answering.
@@ -77,26 +74,22 @@ export function useEssaySessionTimer(): EssaySessionTimer {
       if (!raw) return;
       const saved = JSON.parse(raw) as StoredTimer;
       elapsedMs.value = saved.elapsedMs || 0;
-      if (saved.running && saved.savedAt) {
-        elapsedMs.value += Date.now() - saved.savedAt;
-        start();
-      }
     } catch {
       elapsedMs.value = 0;
     }
   }
 
-  /**
-   * Backgrounding must record the clock as still running so it resumes on return, which is
-   * why the stored `running` flag is written before the interval is torn down.
-   */
   function handleVisibilityChange() {
     if (document.hidden) {
-      persist();
-      stop();
+      resumeAfterVisibility = isRunning.value;
+      pause();
       return;
     }
     restore();
+    if (resumeAfterVisibility) {
+      resumeAfterVisibility = false;
+      start();
+    }
   }
 
   function pause() {
@@ -107,8 +100,8 @@ export function useEssaySessionTimer(): EssaySessionTimer {
   onMounted(() => document.addEventListener('visibilitychange', handleVisibilityChange));
   onBeforeUnmount(() => {
     document.removeEventListener('visibilitychange', handleVisibilityChange);
-    persist();
-    stop();
+    resumeAfterVisibility = false;
+    pause();
     disposed = true;
   });
 
@@ -116,8 +109,7 @@ export function useEssaySessionTimer(): EssaySessionTimer {
     elapsedText: computed(() => formatDuration(elapsedMs.value)),
     isRunning: readonly(isRunning),
     activate(questionSetId: string) {
-      persist();
-      stop();
+      pause();
       elapsedMs.value = 0;
       storageKey = `essay-timer:${questionSetId}`;
     },

--- a/web/src/modules/agent/domain/AgentRunInterruption.ts
+++ b/web/src/modules/agent/domain/AgentRunInterruption.ts
@@ -16,6 +16,16 @@ export class AgentRunLeaseLostError extends Error {
   }
 }
 
+/** Persisted work created by an older input contract cannot be executed safely. */
+export class AgentRunInputIncompatibleError extends Error {
+  readonly code = 'agent_run.input_incompatible';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'AgentRunInputIncompatibleError';
+  }
+}
+
 export function isAgentRunSuspended(error: unknown): error is AgentRunSuspendedError {
   return error instanceof AgentRunSuspendedError
     || (

--- a/web/src/modules/agent/public.ts
+++ b/web/src/modules/agent/public.ts
@@ -21,6 +21,7 @@ export {
 } from './domain/TaskCenterCodes';
 export { AgentRunMachine } from './domain/AgentRunMachine';
 export {
+  AgentRunInputIncompatibleError,
   AgentRunLeaseLostError,
   AgentRunSuspendedError,
   isAgentRunLeaseLost,

--- a/web/src/modules/content/adapters/IndexedDbLearningAssetRepository.ts
+++ b/web/src/modules/content/adapters/IndexedDbLearningAssetRepository.ts
@@ -57,13 +57,28 @@ export class IndexedDbLearningAssetRepository implements LearningAssetRepository
     }
     const offset = query.offset ?? 0;
     if (!Number.isInteger(offset) || offset < 0) throw new RangeError('Learning asset query offset must be a non-negative integer');
-    return (await this.database.getAll<LearningAssetRecord>(TutorIndexedDbStore.LearningAssets))
+    const source = await this.querySource(query);
+    const filtered = source
       .filter((item) => item.examCycleId === query.examCycleId)
       .filter((item) => !query.kinds?.length || query.kinds.includes(item.kind))
       .filter((item) => !query.businessKey || item.businessKey === query.businessKey)
       .filter((item) => !query.status || item.status === query.status)
-      .sort(compareLatest)
+      .filter((item) => !query.purposes?.length || (item.purpose && query.purposes.includes(item.purpose)))
+      .sort(compareLatest);
+    return (query.latestPerBusinessKey ? latestPerBusinessKey(filtered) : filtered)
       .slice(offset, offset + query.limit);
+  }
+
+  async count(query: Omit<LearningAssetQuery, 'limit' | 'offset'>): Promise<number> {
+    const source = await this.querySource(query);
+    const filtered = source
+      .filter((item) => item.examCycleId === query.examCycleId)
+      .filter((item) => !query.kinds?.length || query.kinds.includes(item.kind))
+      .filter((item) => !query.businessKey || item.businessKey === query.businessKey)
+      .filter((item) => !query.status || item.status === query.status)
+      .filter((item) => !query.purposes?.length || (item.purpose && query.purposes.includes(item.purpose)))
+      .sort(compareLatest);
+    return (query.latestPerBusinessKey ? latestPerBusinessKey(filtered) : filtered).length;
   }
 
   async listAll(examCycleId: ExamCycleId): Promise<readonly LearningAssetRecord[]> {
@@ -105,8 +120,28 @@ export class IndexedDbLearningAssetRepository implements LearningAssetRepository
         });
       });
   }
+
+  private async querySource(
+    query: Pick<LearningAssetQuery, 'examCycleId' | 'kinds' | 'purposes' | 'status'>
+  ): Promise<readonly LearningAssetRecord[]> {
+    if (query.kinds?.length === 1 && query.purposes?.length && query.status) {
+      const pages = await Promise.all(query.purposes.map((purpose) => this.database.getAllByIndex<LearningAssetRecord>(
+        TutorIndexedDbStore.LearningAssets,
+        'by_cycle_kind_purpose_status',
+        [query.examCycleId, query.kinds![0], purpose, query.status!]
+      )));
+      return pages.flat();
+    }
+    return this.database.getAll<LearningAssetRecord>(TutorIndexedDbStore.LearningAssets);
+  }
 }
 
 function compareLatest(left: LearningAssetRecord, right: LearningAssetRecord): number {
   return right.updatedAt - left.updatedAt || right.version - left.version || right.id.localeCompare(left.id);
+}
+
+function latestPerBusinessKey(items: readonly LearningAssetRecord[]): LearningAssetRecord[] {
+  const latest = new Map<string, LearningAssetRecord>();
+  for (const item of items) if (!latest.has(item.businessKey)) latest.set(item.businessKey, item);
+  return [...latest.values()];
 }

--- a/web/src/modules/content/adapters/IndexedDbLearningAssetRepository.ts
+++ b/web/src/modules/content/adapters/IndexedDbLearningAssetRepository.ts
@@ -48,7 +48,7 @@ export class IndexedDbLearningAssetRepository implements LearningAssetRepository
         && item.businessKey === businessKey
         && item.status !== LearningAssetStatus.Retired
       ))
-      .sort(compareLatest)[0];
+      .sort(compareBusinessVersion)[0];
   }
 
   async list(query: LearningAssetQuery): Promise<readonly LearningAssetRecord[]> {
@@ -58,33 +58,22 @@ export class IndexedDbLearningAssetRepository implements LearningAssetRepository
     const offset = query.offset ?? 0;
     if (!Number.isInteger(offset) || offset < 0) throw new RangeError('Learning asset query offset must be a non-negative integer');
     const source = await this.querySource(query);
-    const filtered = source
-      .filter((item) => item.examCycleId === query.examCycleId)
-      .filter((item) => !query.kinds?.length || query.kinds.includes(item.kind))
-      .filter((item) => !query.businessKey || item.businessKey === query.businessKey)
-      .filter((item) => !query.status || item.status === query.status)
-      .filter((item) => !query.purposes?.length || (item.purpose && query.purposes.includes(item.purpose)))
-      .sort(compareLatest);
-    return (query.latestPerBusinessKey ? latestPerBusinessKey(filtered) : filtered)
+    const filtered = source.filter((item) => matchesQuery(item, query));
+    return (query.latestPerBusinessKey ? latestPerBusinessKey(filtered) : [...filtered])
+      .sort(compareTimeline)
       .slice(offset, offset + query.limit);
   }
 
   async count(query: Omit<LearningAssetQuery, 'limit' | 'offset'>): Promise<number> {
     const source = await this.querySource(query);
-    const filtered = source
-      .filter((item) => item.examCycleId === query.examCycleId)
-      .filter((item) => !query.kinds?.length || query.kinds.includes(item.kind))
-      .filter((item) => !query.businessKey || item.businessKey === query.businessKey)
-      .filter((item) => !query.status || item.status === query.status)
-      .filter((item) => !query.purposes?.length || (item.purpose && query.purposes.includes(item.purpose)))
-      .sort(compareLatest);
+    const filtered = source.filter((item) => matchesQuery(item, query));
     return (query.latestPerBusinessKey ? latestPerBusinessKey(filtered) : filtered).length;
   }
 
   async listAll(examCycleId: ExamCycleId): Promise<readonly LearningAssetRecord[]> {
     return (await this.database.getAll<LearningAssetRecord>(TutorIndexedDbStore.LearningAssets))
       .filter((item) => item.examCycleId === examCycleId)
-      .sort(compareLatest);
+      .sort(compareTimeline);
   }
 
   async retire(id: string, updatedAt: InstantMs, context: TransactionContext): Promise<void> {
@@ -136,12 +125,30 @@ export class IndexedDbLearningAssetRepository implements LearningAssetRepository
   }
 }
 
-function compareLatest(left: LearningAssetRecord, right: LearningAssetRecord): number {
+function matchesQuery(
+  item: LearningAssetRecord,
+  query: Pick<LearningAssetQuery, 'examCycleId' | 'kinds' | 'businessKey' | 'status' | 'purposes'>
+): boolean {
+  return item.examCycleId === query.examCycleId
+    && (!query.kinds?.length || query.kinds.includes(item.kind))
+    && (!query.businessKey || item.businessKey === query.businessKey)
+    && (!query.status || item.status === query.status)
+    && (!query.purposes?.length || Boolean(item.purpose && query.purposes.includes(item.purpose)));
+}
+
+function compareTimeline(left: LearningAssetRecord, right: LearningAssetRecord): number {
   return right.updatedAt - left.updatedAt || right.version - left.version || right.id.localeCompare(left.id);
+}
+
+function compareBusinessVersion(left: LearningAssetRecord, right: LearningAssetRecord): number {
+  return right.version - left.version || right.updatedAt - left.updatedAt || right.id.localeCompare(left.id);
 }
 
 function latestPerBusinessKey(items: readonly LearningAssetRecord[]): LearningAssetRecord[] {
   const latest = new Map<string, LearningAssetRecord>();
-  for (const item of items) if (!latest.has(item.businessKey)) latest.set(item.businessKey, item);
+  for (const item of items) {
+    const current = latest.get(item.businessKey);
+    if (!current || compareBusinessVersion(item, current) < 0) latest.set(item.businessKey, item);
+  }
   return [...latest.values()];
 }

--- a/web/src/modules/content/adapters/SqliteLearningAssetRepository.ts
+++ b/web/src/modules/content/adapters/SqliteLearningAssetRepository.ts
@@ -7,7 +7,7 @@ import type {
   LearningAssetRecord,
   LearningAssetRepository
 } from '../contracts/LearningAssetRepository';
-import type { LearningAssetKind, LearningAssetStatus } from '../domain/LearningAssetCodes';
+import type { LearningAssetKind, LearningAssetPurpose, LearningAssetStatus } from '../domain/LearningAssetCodes';
 
 interface LearningAssetRow extends SqlRow {
   id: string;
@@ -16,6 +16,7 @@ interface LearningAssetRow extends SqlRow {
   business_key: string;
   title: string;
   status: LearningAssetStatus;
+  purpose: LearningAssetPurpose | null;
   payload_json: string;
   source_agent_run_id: string | null;
   version: number;
@@ -32,8 +33,8 @@ export class SqliteLearningAssetRepository implements LearningAssetRepository {
   async save(asset: LearningAssetRecord, context: TransactionContext): Promise<void> {
     await this.scope.resolve(context).run(
       `INSERT INTO learning_assets(
-        id,exam_cycle_id,kind,business_key,title,status,payload_json,source_agent_run_id,version,created_at,updated_at
-      ) VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
+        id,exam_cycle_id,kind,business_key,title,status,purpose,payload_json,source_agent_run_id,version,created_at,updated_at
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
       [
         asset.id,
         asset.examCycleId,
@@ -41,6 +42,7 @@ export class SqliteLearningAssetRepository implements LearningAssetRepository {
         asset.businessKey,
         asset.title,
         asset.status,
+        asset.purpose ?? null,
         JSON.stringify(asset.payload),
         asset.sourceAgentRunId ?? null,
         asset.version,
@@ -53,10 +55,10 @@ export class SqliteLearningAssetRepository implements LearningAssetRepository {
   async saveDraft(asset: LearningAssetRecord, context: TransactionContext): Promise<void> {
     await this.scope.resolve(context).run(
       `INSERT INTO learning_assets(
-        id,exam_cycle_id,kind,business_key,title,status,payload_json,source_agent_run_id,version,created_at,updated_at
-      ) VALUES (?,?,?,?,?,?,?,?,?,?,?)
+        id,exam_cycle_id,kind,business_key,title,status,purpose,payload_json,source_agent_run_id,version,created_at,updated_at
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
       ON CONFLICT(id) DO UPDATE SET
-        title=excluded.title,status=excluded.status,payload_json=excluded.payload_json,
+        title=excluded.title,status=excluded.status,purpose=excluded.purpose,payload_json=excluded.payload_json,
         source_agent_run_id=excluded.source_agent_run_id,updated_at=excluded.updated_at`,
       [
         asset.id,
@@ -65,6 +67,7 @@ export class SqliteLearningAssetRepository implements LearningAssetRepository {
         asset.businessKey,
         asset.title,
         asset.status,
+        asset.purpose ?? null,
         JSON.stringify(asset.payload),
         asset.sourceAgentRunId ?? null,
         asset.version,
@@ -102,27 +105,59 @@ export class SqliteLearningAssetRepository implements LearningAssetRepository {
     }
     const offset = query.offset ?? 0;
     if (!Number.isInteger(offset) || offset < 0) throw new RangeError('Learning asset query offset must be a non-negative integer');
-    const conditions = ['exam_cycle_id=?'];
+    const conditions = ['asset.exam_cycle_id=?'];
     const parameters: Array<string | number> = [query.examCycleId];
     if (query.kinds?.length) {
-      conditions.push(`kind IN (${query.kinds.map(() => '?').join(',')})`);
+      conditions.push(`asset.kind IN (${query.kinds.map(() => '?').join(',')})`);
       parameters.push(...query.kinds);
     }
     if (query.businessKey) {
-      conditions.push('business_key=?');
+      conditions.push('asset.business_key=?');
       parameters.push(query.businessKey);
     }
     if (query.status) {
-      conditions.push('status=?');
+      conditions.push('asset.status=?');
       parameters.push(query.status);
+    }
+    if (query.purposes?.length) {
+      conditions.push(`asset.purpose IN (${query.purposes.map(() => '?').join(',')})`);
+      parameters.push(...query.purposes);
     }
     parameters.push(query.limit, offset);
     const rows = await this.database.query<LearningAssetRow>(
-      `SELECT * FROM learning_assets WHERE ${conditions.join(' AND ')}
-       ORDER BY updated_at DESC,version DESC,id DESC LIMIT ? OFFSET ?`,
+      `SELECT asset.* FROM learning_assets asset WHERE ${conditions.join(' AND ')}
+       ${latestPredicate(query)}
+       ORDER BY asset.updated_at DESC,asset.version DESC,asset.id DESC LIMIT ? OFFSET ?`,
       parameters
     );
     return rows.map(mapRow);
+  }
+
+  async count(query: Omit<LearningAssetQuery, 'limit' | 'offset'>): Promise<number> {
+    const conditions = ['asset.exam_cycle_id=?'];
+    const parameters: Array<string | number> = [query.examCycleId];
+    if (query.kinds?.length) {
+      conditions.push(`asset.kind IN (${query.kinds.map(() => '?').join(',')})`);
+      parameters.push(...query.kinds);
+    }
+    if (query.businessKey) {
+      conditions.push('asset.business_key=?');
+      parameters.push(query.businessKey);
+    }
+    if (query.status) {
+      conditions.push('asset.status=?');
+      parameters.push(query.status);
+    }
+    if (query.purposes?.length) {
+      conditions.push(`asset.purpose IN (${query.purposes.map(() => '?').join(',')})`);
+      parameters.push(...query.purposes);
+    }
+    const rows = await this.database.query<{ total: number } & SqlRow>(
+      `SELECT COUNT(*) AS total FROM learning_assets asset WHERE ${conditions.join(' AND ')}
+       ${latestPredicate(query)}`,
+      parameters
+    );
+    return Number(rows[0]?.total || 0);
   }
 
   async listAll(examCycleId: ExamCycleId): Promise<readonly LearningAssetRecord[]> {
@@ -155,6 +190,17 @@ export class SqliteLearningAssetRepository implements LearningAssetRepository {
   }
 }
 
+function latestPredicate(query: Pick<LearningAssetQuery, 'latestPerBusinessKey'>): string {
+  if (!query.latestPerBusinessKey) return '';
+  return `AND NOT EXISTS (
+    SELECT 1 FROM learning_assets newer
+    WHERE newer.exam_cycle_id=asset.exam_cycle_id
+      AND newer.kind=asset.kind
+      AND newer.business_key=asset.business_key
+      AND (newer.version>asset.version OR (newer.version=asset.version AND newer.id>asset.id))
+  )`;
+}
+
 function mapRow(row: LearningAssetRow): LearningAssetRecord {
   return {
     id: row.id,
@@ -163,6 +209,7 @@ function mapRow(row: LearningAssetRow): LearningAssetRecord {
     businessKey: row.business_key,
     title: row.title,
     status: row.status,
+    purpose: row.purpose ?? undefined,
     payload: JSON.parse(row.payload_json) as JsonObject,
     sourceAgentRunId: row.source_agent_run_id ?? undefined,
     version: row.version,

--- a/web/src/modules/content/adapters/SqliteLearningAssetRepository.ts
+++ b/web/src/modules/content/adapters/SqliteLearningAssetRepository.ts
@@ -105,56 +105,41 @@ export class SqliteLearningAssetRepository implements LearningAssetRepository {
     }
     const offset = query.offset ?? 0;
     if (!Number.isInteger(offset) || offset < 0) throw new RangeError('Learning asset query offset must be a non-negative integer');
-    const conditions = ['asset.exam_cycle_id=?'];
-    const parameters: Array<string | number> = [query.examCycleId];
-    if (query.kinds?.length) {
-      conditions.push(`asset.kind IN (${query.kinds.map(() => '?').join(',')})`);
-      parameters.push(...query.kinds);
-    }
-    if (query.businessKey) {
-      conditions.push('asset.business_key=?');
-      parameters.push(query.businessKey);
-    }
-    if (query.status) {
-      conditions.push('asset.status=?');
-      parameters.push(query.status);
-    }
-    if (query.purposes?.length) {
-      conditions.push(`asset.purpose IN (${query.purposes.map(() => '?').join(',')})`);
-      parameters.push(...query.purposes);
-    }
+    const { conditions, parameters } = buildFilteredQuery(query);
     parameters.push(query.limit, offset);
     const rows = await this.database.query<LearningAssetRow>(
-      `SELECT asset.* FROM learning_assets asset WHERE ${conditions.join(' AND ')}
-       ${latestPredicate(query)}
-       ORDER BY asset.updated_at DESC,asset.version DESC,asset.id DESC LIMIT ? OFFSET ?`,
+      query.latestPerBusinessKey
+        ? `WITH ranked AS (
+             SELECT asset.*,
+               ROW_NUMBER() OVER (
+                 PARTITION BY asset.exam_cycle_id,asset.kind,asset.business_key
+                 ORDER BY asset.version DESC,asset.updated_at DESC,asset.id DESC
+               ) AS asset_rank
+             FROM learning_assets asset
+             WHERE ${conditions.join(' AND ')}
+           )
+           SELECT * FROM ranked WHERE asset_rank=1
+           ORDER BY updated_at DESC,version DESC,id DESC LIMIT ? OFFSET ?`
+        : `SELECT asset.* FROM learning_assets asset WHERE ${conditions.join(' AND ')}
+           ORDER BY asset.updated_at DESC,asset.version DESC,asset.id DESC LIMIT ? OFFSET ?`,
       parameters
     );
     return rows.map(mapRow);
   }
 
   async count(query: Omit<LearningAssetQuery, 'limit' | 'offset'>): Promise<number> {
-    const conditions = ['asset.exam_cycle_id=?'];
-    const parameters: Array<string | number> = [query.examCycleId];
-    if (query.kinds?.length) {
-      conditions.push(`asset.kind IN (${query.kinds.map(() => '?').join(',')})`);
-      parameters.push(...query.kinds);
-    }
-    if (query.businessKey) {
-      conditions.push('asset.business_key=?');
-      parameters.push(query.businessKey);
-    }
-    if (query.status) {
-      conditions.push('asset.status=?');
-      parameters.push(query.status);
-    }
-    if (query.purposes?.length) {
-      conditions.push(`asset.purpose IN (${query.purposes.map(() => '?').join(',')})`);
-      parameters.push(...query.purposes);
-    }
+    const { conditions, parameters } = buildFilteredQuery(query);
     const rows = await this.database.query<{ total: number } & SqlRow>(
-      `SELECT COUNT(*) AS total FROM learning_assets asset WHERE ${conditions.join(' AND ')}
-       ${latestPredicate(query)}`,
+      query.latestPerBusinessKey
+        ? `SELECT COUNT(*) AS total FROM (
+             SELECT ROW_NUMBER() OVER (
+               PARTITION BY asset.exam_cycle_id,asset.kind,asset.business_key
+               ORDER BY asset.version DESC,asset.updated_at DESC,asset.id DESC
+             ) AS asset_rank
+             FROM learning_assets asset
+             WHERE ${conditions.join(' AND ')}
+           ) ranked WHERE asset_rank=1`
+        : `SELECT COUNT(*) AS total FROM learning_assets asset WHERE ${conditions.join(' AND ')}`,
       parameters
     );
     return Number(rows[0]?.total || 0);
@@ -190,15 +175,28 @@ export class SqliteLearningAssetRepository implements LearningAssetRepository {
   }
 }
 
-function latestPredicate(query: Pick<LearningAssetQuery, 'latestPerBusinessKey'>): string {
-  if (!query.latestPerBusinessKey) return '';
-  return `AND NOT EXISTS (
-    SELECT 1 FROM learning_assets newer
-    WHERE newer.exam_cycle_id=asset.exam_cycle_id
-      AND newer.kind=asset.kind
-      AND newer.business_key=asset.business_key
-      AND (newer.version>asset.version OR (newer.version=asset.version AND newer.id>asset.id))
-  )`;
+function buildFilteredQuery(
+  query: Pick<LearningAssetQuery, 'examCycleId' | 'kinds' | 'businessKey' | 'status' | 'purposes'>
+): { conditions: string[]; parameters: Array<string | number> } {
+  const conditions = ['asset.exam_cycle_id=?'];
+  const parameters: Array<string | number> = [query.examCycleId];
+  if (query.kinds?.length) {
+    conditions.push(`asset.kind IN (${query.kinds.map(() => '?').join(',')})`);
+    parameters.push(...query.kinds);
+  }
+  if (query.businessKey) {
+    conditions.push('asset.business_key=?');
+    parameters.push(query.businessKey);
+  }
+  if (query.status) {
+    conditions.push('asset.status=?');
+    parameters.push(query.status);
+  }
+  if (query.purposes?.length) {
+    conditions.push(`asset.purpose IN (${query.purposes.map(() => '?').join(',')})`);
+    parameters.push(...query.purposes);
+  }
+  return { conditions, parameters };
 }
 
 function mapRow(row: LearningAssetRow): LearningAssetRecord {

--- a/web/src/modules/content/application/LearningAssetStore.ts
+++ b/web/src/modules/content/application/LearningAssetStore.ts
@@ -7,6 +7,7 @@ import type {
 } from '../contracts/LearningAssetRepository';
 import {
   LearningAssetKind,
+  LearningAssetPurpose,
   LearningAssetStatus
 } from '../domain/LearningAssetCodes';
 
@@ -18,6 +19,7 @@ export interface SaveLearningAssetCommand {
   readonly payload: JsonObject;
   readonly sourceAgentRunId?: string;
   readonly status?: LearningAssetStatus;
+  readonly purpose?: LearningAssetPurpose;
 }
 
 export class LearningAssetStore {
@@ -44,6 +46,7 @@ export class LearningAssetStore {
         businessKey,
         title: command.title.trim() || command.kind,
         status: command.status ?? LearningAssetStatus.Ready,
+        purpose: resolvePurpose(command),
         payload: command.payload,
         sourceAgentRunId: command.sourceAgentRunId,
         version: (previous?.version ?? 0) + 1,
@@ -74,6 +77,7 @@ export class LearningAssetStore {
       businessKey,
       title: command.title.trim() || command.kind,
       status: LearningAssetStatus.Draft,
+      purpose: resolvePurpose(command),
       payload: command.payload,
       sourceAgentRunId: command.sourceAgentRunId,
       version: previous?.version ?? 1,
@@ -98,6 +102,10 @@ export class LearningAssetStore {
     return this.repository.list(query);
   }
 
+  count(query: Omit<LearningAssetQuery, 'limit' | 'offset'>): Promise<number> {
+    return this.repository.count(query);
+  }
+
   async retire(id: string): Promise<void> {
     await this.unitOfWork.run(async (context) => {
       await this.repository.retire(id, this.clock.now(), context);
@@ -109,6 +117,23 @@ export class LearningAssetStore {
       await this.repository.retireBusinessKey(examCycleId, kind, businessKey, this.clock.now(), context);
     });
   }
+}
+
+function resolvePurpose(command: SaveLearningAssetCommand): LearningAssetPurpose | undefined {
+  if (command.purpose) return command.purpose;
+  if (command.kind !== LearningAssetKind.EssayQuestion) return undefined;
+  const rawContext = command.payload.essayContext;
+  const context = rawContext && typeof rawContext === 'object' && !Array.isArray(rawContext)
+    ? rawContext as JsonObject
+    : {};
+  if (context.purpose === LearningAssetPurpose.Mock) return LearningAssetPurpose.Mock;
+  if (context.purpose === LearningAssetPurpose.TrueQuestion || context.entryMode === 'true') {
+    return LearningAssetPurpose.TrueQuestion;
+  }
+  if (context.purpose === LearningAssetPurpose.Practice || context.entryMode === 'self' || context.entryMode === 'tutor') {
+    return LearningAssetPurpose.Practice;
+  }
+  return LearningAssetPurpose.LegacyUnknown;
 }
 
 function isVersionConflict(error: unknown): boolean {

--- a/web/src/modules/content/application/LearningAssetStore.ts
+++ b/web/src/modules/content/application/LearningAssetStore.ts
@@ -33,6 +33,7 @@ export class LearningAssetStore {
   async save(command: SaveLearningAssetCommand): Promise<LearningAssetRecord> {
     const businessKey = command.businessKey.trim();
     if (!businessKey) throw new Error('Learning asset businessKey is required');
+    assertPurposeBoundary(command);
     // A generation retry can race with a previous completion between the
     // read and insert. Re-read the version once instead of failing the whole
     // Agent run on the expected UNIQUE(version) conflict.
@@ -68,6 +69,7 @@ export class LearningAssetStore {
   async saveDraft(command: SaveLearningAssetCommand): Promise<LearningAssetRecord> {
     const businessKey = command.businessKey.trim();
     if (!businessKey) throw new Error('Learning asset businessKey is required');
+    assertPurposeBoundary(command);
     const previous = await this.repository.findLatest(command.examCycleId, command.kind, businessKey);
     const now = this.clock.now();
     const asset: LearningAssetRecord = {
@@ -120,20 +122,13 @@ export class LearningAssetStore {
 }
 
 function resolvePurpose(command: SaveLearningAssetCommand): LearningAssetPurpose | undefined {
-  if (command.purpose) return command.purpose;
-  if (command.kind !== LearningAssetKind.EssayQuestion) return undefined;
-  const rawContext = command.payload.essayContext;
-  const context = rawContext && typeof rawContext === 'object' && !Array.isArray(rawContext)
-    ? rawContext as JsonObject
-    : {};
-  if (context.purpose === LearningAssetPurpose.Mock) return LearningAssetPurpose.Mock;
-  if (context.purpose === LearningAssetPurpose.TrueQuestion || context.entryMode === 'true') {
-    return LearningAssetPurpose.TrueQuestion;
+  return command.purpose;
+}
+
+function assertPurposeBoundary(command: SaveLearningAssetCommand): void {
+  if (command.kind === LearningAssetKind.EssayQuestion && !command.purpose) {
+    throw new TypeError('Essay question assets require an explicit purpose');
   }
-  if (context.purpose === LearningAssetPurpose.Practice || context.entryMode === 'self' || context.entryMode === 'tutor') {
-    return LearningAssetPurpose.Practice;
-  }
-  return LearningAssetPurpose.LegacyUnknown;
 }
 
 function isVersionConflict(error: unknown): boolean {

--- a/web/src/modules/content/contracts/LearningAssetRepository.ts
+++ b/web/src/modules/content/contracts/LearningAssetRepository.ts
@@ -1,6 +1,10 @@
 import type { TransactionContext } from '@/capabilities/database/public';
 import type { ExamCycleId, InstantMs, JsonObject } from '@/kernel/public';
-import type { LearningAssetKind, LearningAssetStatus } from '../domain/LearningAssetCodes';
+import type {
+  LearningAssetKind,
+  LearningAssetPurpose,
+  LearningAssetStatus
+} from '../domain/LearningAssetCodes';
 
 export interface LearningAssetRecord {
   readonly id: string;
@@ -9,6 +13,7 @@ export interface LearningAssetRecord {
   readonly businessKey: string;
   readonly title: string;
   readonly status: LearningAssetStatus;
+  readonly purpose?: LearningAssetPurpose;
   readonly payload: JsonObject;
   readonly sourceAgentRunId?: string;
   readonly version: number;
@@ -21,6 +26,8 @@ export interface LearningAssetQuery {
   readonly kinds?: readonly LearningAssetKind[];
   readonly businessKey?: string;
   readonly status?: LearningAssetStatus;
+  readonly purposes?: readonly LearningAssetPurpose[];
+  readonly latestPerBusinessKey?: boolean;
   readonly offset?: number;
   readonly limit: number;
 }
@@ -31,6 +38,7 @@ export interface LearningAssetRepository {
   find(id: string): Promise<LearningAssetRecord | undefined>;
   findLatest(examCycleId: ExamCycleId, kind: LearningAssetKind, businessKey: string): Promise<LearningAssetRecord | undefined>;
   list(query: LearningAssetQuery): Promise<readonly LearningAssetRecord[]>;
+  count(query: Omit<LearningAssetQuery, 'limit' | 'offset'>): Promise<number>;
   listAll(examCycleId: ExamCycleId): Promise<readonly LearningAssetRecord[]>;
   retire(id: string, updatedAt: InstantMs, context: TransactionContext): Promise<void>;
   retireBusinessKey(

--- a/web/src/modules/content/contracts/LearningAssetRepository.ts
+++ b/web/src/modules/content/contracts/LearningAssetRepository.ts
@@ -27,6 +27,11 @@ export interface LearningAssetQuery {
   readonly businessKey?: string;
   readonly status?: LearningAssetStatus;
   readonly purposes?: readonly LearningAssetPurpose[];
+  /**
+   * Select the highest version among records that match the other query filters.
+   * Results are always ordered by the repository timeline order:
+   * updatedAt DESC, version DESC, id DESC.
+   */
   readonly latestPerBusinessKey?: boolean;
   readonly offset?: number;
   readonly limit: number;

--- a/web/src/modules/content/domain/LearningAssetCodes.ts
+++ b/web/src/modules/content/domain/LearningAssetCodes.ts
@@ -22,3 +22,12 @@ export const LearningAssetStatus = {
 } as const;
 
 export type LearningAssetStatus = typeof LearningAssetStatus[keyof typeof LearningAssetStatus];
+
+export const LearningAssetPurpose = {
+  Practice: 'practice',
+  Mock: 'mock',
+  TrueQuestion: 'true_question',
+  LegacyUnknown: 'legacy_unknown'
+} as const;
+
+export type LearningAssetPurpose = typeof LearningAssetPurpose[keyof typeof LearningAssetPurpose];

--- a/web/src/modules/content/public.ts
+++ b/web/src/modules/content/public.ts
@@ -139,8 +139,10 @@ export type {
 } from './contracts/QuestionContent';
 export {
   LearningAssetKind,
+  LearningAssetPurpose,
   LearningAssetStatus,
   type LearningAssetKind as LearningAssetKindCode,
+  type LearningAssetPurpose as LearningAssetPurposeCode,
   type LearningAssetStatus as LearningAssetStatusCode
 } from './domain/LearningAssetCodes';
 export type {

--- a/web/src/services/EssayDraftAutosave.ts
+++ b/web/src/services/EssayDraftAutosave.ts
@@ -1,0 +1,61 @@
+import type { EssayContext } from './EssayFlowService';
+
+export type EssayDraftWriter = (draft: string, context: EssayContext) => Promise<void>;
+
+interface PendingDraft {
+  readonly draft: string;
+  readonly context: EssayContext;
+}
+
+/**
+ * Long-form answering types thousands of characters; persisting on every keystroke would
+ * put the database in the input path. Writes are coalesced and kept strictly in order so
+ * the last keystroke always wins.
+ */
+export class EssayDraftAutosave {
+  /** Inferred so the debounce works under both the DOM and Node timer typings. */
+  private timerId: ReturnType<typeof setTimeout> | null = null;
+  private pending: PendingDraft | null = null;
+  private queue: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly write: EssayDraftWriter,
+    private readonly delayMs = 180,
+    private readonly onError: (cause: unknown) => void = () => undefined
+  ) {}
+
+  schedule(draft: string, context: EssayContext): void {
+    this.pending = { draft, context };
+    if (this.timerId !== null) clearTimeout(this.timerId);
+    this.timerId = setTimeout(() => {
+      this.timerId = null;
+      this.enqueuePending();
+    }, this.delayMs);
+  }
+
+  /** Persists any coalesced draft right away and resolves once it has landed. */
+  flush(): Promise<void> {
+    if (this.timerId !== null) {
+      clearTimeout(this.timerId);
+      this.timerId = null;
+    }
+    this.enqueuePending();
+    return this.queue;
+  }
+
+  /** Drops a scheduled write, for when the draft is being replaced from storage anyway. */
+  cancel(): void {
+    if (this.timerId !== null) clearTimeout(this.timerId);
+    this.timerId = null;
+    this.pending = null;
+  }
+
+  private enqueuePending(): void {
+    const pending = this.pending;
+    if (!pending) return;
+    this.pending = null;
+    this.queue = this.queue
+      .then(() => this.write(pending.draft, pending.context))
+      .catch((cause) => this.onError(cause));
+  }
+}

--- a/web/src/services/EssayRepository.ts
+++ b/web/src/services/EssayRepository.ts
@@ -2,6 +2,7 @@ import type { TutorDatabaseRuntime } from '@/composition-root/public';
 import type { ExamCycleId, JsonObject } from '@/kernel/public';
 import {
   LearningAssetKind,
+  LearningAssetPurpose,
   LearningAssetStatus,
   type LearningAssetRecord
 } from '@/modules/content/public';
@@ -165,58 +166,6 @@ export class EssayRepository {
     return this.getState(normalized);
   }
 
-  async saveQuestion(question: EssayQuestionRecord, context: EssayContext): Promise<EssayLocalState> {
-    const normalized = normalizeContext(context);
-    const { runtime, examCycleId } = await this.activeCycle();
-    await runtime.learningAssetStore.save({
-      examCycleId,
-      kind: LearningAssetKind.EssayQuestion,
-      businessKey: businessKey(normalized),
-      title: question.title,
-      payload: { question, essayContext: normalized } as unknown as JsonObject
-    });
-    await runtime.learningAssetStore.retireBusinessKey(
-      examCycleId,
-      LearningAssetKind.EssayDraft,
-      businessKey(normalized)
-    );
-    return this.getState(normalized);
-  }
-
-  async saveFeedback(
-    content: string,
-    feedback: string,
-    structured: {
-      score?: number;
-      dimensions?: EssayFeedbackDimension[];
-      suggestions?: string[];
-    } | undefined,
-    context: EssayContext
-  ): Promise<EssayLocalState> {
-    const normalized = normalizeContext(context);
-    const current = await this.getState(normalized);
-    if (!current.question) throw new Error('当前没有申论题目，无法保存批改记录');
-    const { runtime, examCycleId } = await this.activeCycle();
-    await runtime.learningAssetStore.save({
-      examCycleId,
-      kind: LearningAssetKind.EssayAttempt,
-      businessKey: businessKey(normalized),
-      title: `${current.question.title} · 批改`,
-      payload: {
-        question: current.question,
-        content,
-        feedback,
-        score: structured?.score,
-        dimensions: structured?.dimensions,
-        suggestions: structured?.suggestions,
-        wordCount: content.length,
-        essayContext: normalized
-      } as unknown as JsonObject
-    });
-    await this.saveDraft(content, normalized);
-    return this.getState(normalized);
-  }
-
   async resetDraft(context: EssayContext): Promise<EssayLocalState> {
     return this.saveDraft('', context);
   }
@@ -232,19 +181,18 @@ export class EssayRepository {
     return this.getState(normalized);
   }
 
-  async listStates(): Promise<EssayQuestionSetSummary[]> {
+  async listStates(options: { offset?: number; limit?: number } = {}): Promise<EssayQuestionSetSummary[]> {
     const { runtime, examCycleId } = await this.activeCycle();
     const assets = await runtime.learningAssetStore.list({
       examCycleId,
       kinds: [LearningAssetKind.EssayQuestion],
       status: LearningAssetStatus.Ready,
-      limit: 200
+      purposes: [LearningAssetPurpose.Practice, LearningAssetPurpose.TrueQuestion],
+      latestPerBusinessKey: true,
+      offset: options.offset ?? 0,
+      limit: options.limit ?? 20
     });
-    const latest = new Map<string, LearningAssetRecord>();
-    assets.forEach((asset) => {
-      if (!latest.has(asset.businessKey)) latest.set(asset.businessKey, asset);
-    });
-    const items = Array.from(latest.values()).map((asset) => {
+    const items = assets.map((asset) => {
       const rawContext = asset.payload.essayContext;
       const record = rawContext && typeof rawContext === 'object' && !Array.isArray(rawContext)
         ? rawContext as Record<string, unknown>
@@ -265,6 +213,17 @@ export class EssayRepository {
       };
     });
     return items.sort((left, right) => right.updatedAt - left.updatedAt);
+  }
+
+  async countStates(): Promise<number> {
+    const { runtime, examCycleId } = await this.activeCycle();
+    return runtime.learningAssetStore.count({
+      examCycleId,
+      kinds: [LearningAssetKind.EssayQuestion],
+      status: LearningAssetStatus.Ready,
+      purposes: [LearningAssetPurpose.Practice, LearningAssetPurpose.TrueQuestion],
+      latestPerBusinessKey: true
+    });
   }
 
   private async activeCycle(): Promise<{ runtime: TutorDatabaseRuntime; examCycleId: ExamCycleId }> {

--- a/web/src/services/EssayRepository.ts
+++ b/web/src/services/EssayRepository.ts
@@ -62,6 +62,7 @@ export interface EssayLocalState {
 
 export interface EssayQuestionSetSummary {
   key: string;
+  classification: LearningAssetPurpose;
   context: EssayContext;
   question: EssayQuestionRecord | null;
   updatedAt: number;
@@ -153,7 +154,8 @@ export class EssayRepository {
     };
   }
 
-  async saveDraft(draft: string, context: EssayContext): Promise<EssayLocalState> {
+  /** Write-only so autosave never pays for a full state read on the typing path. */
+  async saveDraft(draft: string, context: EssayContext): Promise<void> {
     const normalized = normalizeContext(context);
     const { runtime, examCycleId } = await this.activeCycle();
     await runtime.learningAssetStore.saveDraft({
@@ -163,11 +165,11 @@ export class EssayRepository {
       title: `${normalized.topic}草稿 · ${normalized.date}`,
       payload: { draft, essayContext: normalized } as unknown as JsonObject
     });
-    return this.getState(normalized);
   }
 
   async resetDraft(context: EssayContext): Promise<EssayLocalState> {
-    return this.saveDraft('', context);
+    await this.saveDraft('', context);
+    return this.getState(context);
   }
 
   async deleteState(context: EssayContext): Promise<EssayLocalState> {
@@ -187,7 +189,11 @@ export class EssayRepository {
       examCycleId,
       kinds: [LearningAssetKind.EssayQuestion],
       status: LearningAssetStatus.Ready,
-      purposes: [LearningAssetPurpose.Practice, LearningAssetPurpose.TrueQuestion],
+      purposes: [
+        LearningAssetPurpose.Practice,
+        LearningAssetPurpose.TrueQuestion,
+        LearningAssetPurpose.LegacyUnknown
+      ],
       latestPerBusinessKey: true,
       offset: options.offset ?? 0,
       limit: options.limit ?? 20
@@ -207,12 +213,13 @@ export class EssayRepository {
       };
       return {
         key: asset.businessKey,
+        classification: asset.purpose ?? LearningAssetPurpose.LegacyUnknown,
         context: itemContext,
         question: asQuestion(asset.payload.question),
         updatedAt: asset.updatedAt
       };
     });
-    return items.sort((left, right) => right.updatedAt - left.updatedAt);
+    return items;
   }
 
   async countStates(): Promise<number> {
@@ -221,7 +228,11 @@ export class EssayRepository {
       examCycleId,
       kinds: [LearningAssetKind.EssayQuestion],
       status: LearningAssetStatus.Ready,
-      purposes: [LearningAssetPurpose.Practice, LearningAssetPurpose.TrueQuestion],
+      purposes: [
+        LearningAssetPurpose.Practice,
+        LearningAssetPurpose.TrueQuestion,
+        LearningAssetPurpose.LegacyUnknown
+      ],
       latestPerBusinessKey: true
     });
   }

--- a/web/src/services/ExamFlowService.ts
+++ b/web/src/services/ExamFlowService.ts
@@ -1,17 +1,14 @@
 import { initializeTutorRuntime } from '@/composition-root/public';
 import {
   LearningAssetKind,
+  LearningAssetPurpose,
   LearningAssetStatus,
   type LearningAssetRecord
 } from '@/modules/content/public';
 import { generationTaskService } from './GenerationTaskService';
 import { essayFlowService } from './EssayFlowService';
 import type { AgentTaskEnqueueResult } from './GenerationTaskService';
-import {
-  normalizeEssayQuestionSetMode,
-  isEssayMockContext,
-  type EssayQuestionSetMode
-} from '@/domain/essayQuestionSet';
+import { normalizeEssayQuestionSetMode, type EssayQuestionSetMode } from '@/domain/essayQuestionSet';
 
 export type ExamSubject = '行测' | '申论';
 export type EssayMockType = 'short' | 'long';
@@ -146,40 +143,23 @@ export class ExamFlowService {
     const runtime = await initializeTutorRuntime();
     const cycle = await runtime.candidateRepository.findCurrentCycle();
     if (!cycle) throw new Error('请先完成备考档案。');
-    const assets = subject === '行测'
+    const [assets, essayMockTotal] = subject === '行测'
       ? await runtime.learningAssetStore.list({
         examCycleId: cycle.examCycle.id,
         kinds: [LearningAssetKind.MockManifest],
         status: LearningAssetStatus.Ready,
         limit: 100
-      })
-      : await listEssayMockAssets(runtime, cycle.examCycle.id, 30);
+      }).then((items) => [items, 0] as const)
+      : await Promise.all([
+        listEssayMockAssets(runtime, cycle.examCycle.id, 0, 30),
+        countEssayMockAssets(runtime, cycle.examCycle.id)
+      ]);
     const recentSessions = subject === '行测'
       ? await runtime.learningSessionRepository.listRecent(cycle.examCycle.id, 500)
       : [];
     const history = assets
       .map((asset): ExamHistoryItem | undefined => {
-        if (subject === '申论') {
-          const essayContext = asset.payload.essayContext && typeof asset.payload.essayContext === 'object' && !Array.isArray(asset.payload.essayContext)
-            ? asset.payload.essayContext as Record<string, unknown>
-            : {};
-          const date = typeof essayContext.date === 'string' ? essayContext.date : new Date(asset.createdAt).toISOString().slice(0, 10);
-          return {
-            id: asset.id,
-            subject,
-            date,
-            title: asset.title,
-            questionSetId: asset.businessKey,
-            essayEntryMode: normalizeEssayQuestionSetMode(essayContext.entryMode),
-            essayTopic: typeof essayContext.topic === 'string' ? essayContext.topic : asset.title,
-            essayType: essayContext.type === 'long' ? 'long' : 'short',
-            essayPurpose: 'mock',
-            questionCount: 1,
-            correctCount: 0,
-            accuracy: 0,
-            createdAt: asset.createdAt
-          };
-        }
+        if (subject === '申论') return essayMockHistoryItem(asset);
         const sections = Array.isArray(asset.payload.sections) ? asset.payload.sections : [];
         const setIds = new Set(sections.flatMap((item) => {
           const record = item && typeof item === 'object' && !Array.isArray(item) ? item as Record<string, unknown> : {};
@@ -211,8 +191,18 @@ export class ExamFlowService {
       schemes: SCHEMES,
       focusTags: FOCUS_TAGS,
       history,
-      stats: statsFrom(history)
+      stats: subject === '申论'
+        ? { ...statsFrom(history), total: essayMockTotal }
+        : statsFrom(history)
     };
+  }
+
+  async listEssayMockHistory(offset: number, limit: number): Promise<ExamHistoryItem[]> {
+    const runtime = await initializeTutorRuntime();
+    const cycle = await runtime.candidateRepository.findCurrentCycle();
+    if (!cycle) throw new Error('请先完成备考档案。');
+    const assets = await listEssayMockAssets(runtime, cycle.examCycle.id, offset, limit);
+    return assets.map(essayMockHistoryItem);
   }
 
   async startMock(context: ExamStartContext, idempotencyKey?: string): Promise<AgentTaskEnqueueResult> {
@@ -254,30 +244,57 @@ export const examFlowService = new ExamFlowService();
 async function listEssayMockAssets(
   runtime: Awaited<ReturnType<typeof initializeTutorRuntime>>,
   examCycleId: Parameters<typeof runtime.learningAssetStore.list>[0]['examCycleId'],
-  targetCount: number
+  offset: number,
+  limit: number
 ) {
-  const pageSize = 100;
-  const matches: LearningAssetRecord[] = [];
-  const seenBusinessKeys = new Set<string>();
-  for (let offset = 0; matches.length < targetCount; offset += pageSize) {
-    const page = await runtime.learningAssetStore.list({
-      examCycleId,
-      kinds: [LearningAssetKind.EssayQuestion],
-      status: LearningAssetStatus.Ready,
-      offset,
-      limit: pageSize
-    });
-    for (const asset of page) {
-      if (!isEssayMockAsset(asset) || seenBusinessKeys.has(asset.businessKey)) continue;
-      seenBusinessKeys.add(asset.businessKey);
-      matches.push(asset);
-      if (matches.length >= targetCount) break;
-    }
-    if (page.length < pageSize) break;
-  }
-  return matches.slice(0, targetCount);
+  return runtime.learningAssetStore.list({
+    examCycleId,
+    kinds: [LearningAssetKind.EssayQuestion],
+    status: LearningAssetStatus.Ready,
+    purposes: [LearningAssetPurpose.Mock],
+    latestPerBusinessKey: true,
+    offset,
+    limit
+  });
 }
 
 export function isEssayMockAsset(asset: LearningAssetRecord): boolean {
-  return isEssayMockContext(asset.payload.essayContext);
+  return asset.purpose === LearningAssetPurpose.Mock;
+}
+
+function countEssayMockAssets(
+  runtime: Awaited<ReturnType<typeof initializeTutorRuntime>>,
+  examCycleId: Parameters<typeof runtime.learningAssetStore.list>[0]['examCycleId']
+): Promise<number> {
+  return runtime.learningAssetStore.count({
+    examCycleId,
+    kinds: [LearningAssetKind.EssayQuestion],
+    status: LearningAssetStatus.Ready,
+    purposes: [LearningAssetPurpose.Mock],
+    latestPerBusinessKey: true
+  });
+}
+
+function essayMockHistoryItem(asset: LearningAssetRecord): ExamHistoryItem {
+  const rawContext = asset.payload.essayContext;
+  const essayContext = rawContext && typeof rawContext === 'object' && !Array.isArray(rawContext)
+    ? rawContext as Record<string, unknown>
+    : {};
+  return {
+    id: asset.id,
+    subject: '申论',
+    date: typeof essayContext.date === 'string'
+      ? essayContext.date
+      : new Date(asset.createdAt).toISOString().slice(0, 10),
+    title: asset.title,
+    questionSetId: asset.businessKey,
+    essayEntryMode: normalizeEssayQuestionSetMode(essayContext.entryMode),
+    essayTopic: typeof essayContext.topic === 'string' ? essayContext.topic : asset.title,
+    essayType: essayContext.type === 'long' ? 'long' : 'short',
+    essayPurpose: 'mock',
+    questionCount: 1,
+    correctCount: 0,
+    accuracy: 0,
+    createdAt: asset.createdAt
+  };
 }

--- a/web/src/services/ExamFlowService.ts
+++ b/web/src/services/ExamFlowService.ts
@@ -105,6 +105,17 @@ function statsFrom(history: ExamHistoryItem[]): ExamStats {
   };
 }
 
+function essayMockStats(total: number, history: ExamHistoryItem[]): ExamStats {
+  // Essay mock question assets are not scored records yet. Keep the aggregate
+  // explicitly unscored instead of deriving misleading values from page one.
+  return {
+    total,
+    averageAccuracy: 0,
+    bestAccuracy: 0,
+    latest: history[0]
+  };
+}
+
 export class ExamFlowService {
   readContext(): ExamStartContext {
     const subject = normalizeSubject(localStorage.getItem('exam-subject') || '行测');
@@ -192,7 +203,7 @@ export class ExamFlowService {
       focusTags: FOCUS_TAGS,
       history,
       stats: subject === '申论'
-        ? { ...statsFrom(history), total: essayMockTotal }
+        ? essayMockStats(essayMockTotal, history)
         : statsFrom(history)
     };
   }

--- a/web/src/services/GenerationTaskService.ts
+++ b/web/src/services/GenerationTaskService.ts
@@ -75,6 +75,7 @@ export class GenerationTaskService {
       targetResourceType: TaskTargetType.BusinessOperation,
       targetResourceId: scopeKey,
       inputSnapshot: {
+        taskSchemaVersion: 2,
         projectId,
         intent: input.intent,
         title,

--- a/web/src/stores/essay.ts
+++ b/web/src/stores/essay.ts
@@ -33,7 +33,6 @@ export interface EssayState {
   history: EssayHistoryRecord[];
   preview: EssayAttemptPreview | null;
   context: EssayContext | null;
-  submitMessage: string;
   isLoading: boolean;
   error: string | null;
 }
@@ -43,6 +42,7 @@ const draftAutosave = new EssayDraftAutosave(
   180,
   (cause) => console.warn('[Essay] draft autosave failed', cause)
 );
+let stateLoadRevision = 0;
 
 export const useEssayStore = defineStore('essay', {
   state: (): EssayState => ({
@@ -55,25 +55,32 @@ export const useEssayStore = defineStore('essay', {
     history: [],
     preview: null,
     context: null,
-    submitMessage: '',
     isLoading: true,
     error: null,
   }),
 
   actions: {
     async fetchQuestion(context: EssayContext) {
+      const revision = ++stateLoadRevision;
       this.isLoading = true;
       this.error = null;
       // The pending draft belongs to the set being left, so it must land before switching.
       await draftAutosave.flush();
+      if (revision !== stateLoadRevision) return;
       try {
         this.context = context;
+        this.question = null;
         this.preview = null;
-        this.applyState(await essayRepository.getState(context));
+        this.submission = { content: '', feedback: null, isSubmitting: false };
+        this.history = [];
+        const state = await essayRepository.getState(context);
+        if (revision !== stateLoadRevision || this.context?.questionSetId !== context.questionSetId) return;
+        this.applyState(state);
       } catch (error) {
+        if (revision !== stateLoadRevision) return;
         this.error = error instanceof Error ? error.message : String(error);
       } finally {
-        this.isLoading = false;
+        if (revision === stateLoadRevision) this.isLoading = false;
       }
     },
 
@@ -87,6 +94,7 @@ export const useEssayStore = defineStore('essay', {
       try {
         await draftAutosave.flush();
         const state = await essayRepository.getState(context);
+        if (this.context?.questionSetId !== context.questionSetId) return;
         this.question = state.question;
         this.submission.feedback = state.feedback;
         this.history = state.history;
@@ -103,22 +111,17 @@ export const useEssayStore = defineStore('essay', {
     updateContent(content: string) {
       this.submission.content = content;
       this.submission.feedback = null;
-      this.submitMessage = '';
       draftAutosave.schedule(content, requireEssayContext(this.context));
     },
 
     async submitForGrading(): Promise<AgentRunView | undefined> {
       this.submission.isSubmitting = true;
       this.submission.feedback = null;
-      this.submitMessage = '';
       this.error = null;
       try {
         const context = requireEssayContext(this.context);
         await draftAutosave.flush();
         const result = await essayFlowService.enqueueGrading(this.submission.content, context);
-        this.submitMessage = result.reused
-          ? '本题组已有批改任务在执行，正在等待结果。'
-          : '批改任务已提交，完成后会自动显示。';
         return result.task;
       } catch (error) {
         this.error = error instanceof Error ? error.message : String(error);
@@ -134,7 +137,6 @@ export const useEssayStore = defineStore('essay', {
       try {
         this.preview = null;
         this.applyState(await essayRepository.resetDraft(requireEssayContext(this.context)));
-        this.submitMessage = '';
       } catch (error) {
         this.error = error instanceof Error ? error.message : String(error);
       }
@@ -163,13 +165,13 @@ export const useEssayStore = defineStore('essay', {
     },
 
     reset(options: { loading?: boolean } = {}) {
+      stateLoadRevision += 1;
       void draftAutosave.flush();
       this.question = null;
       this.submission = { content: '', feedback: null, isSubmitting: false };
       this.history = [];
       this.preview = null;
       this.context = null;
-      this.submitMessage = '';
       this.isLoading = options.loading ?? false;
       this.error = null;
     }

--- a/web/src/stores/essay.ts
+++ b/web/src/stores/essay.ts
@@ -87,13 +87,13 @@ export const useEssayStore = defineStore('essay', {
       this.submitMessage = '';
     },
 
-    reset() {
+    reset(options: { loading?: boolean } = {}) {
       this.question = null;
       this.submission = { content: '', feedback: null, isSubmitting: false };
       this.history = [];
       this.context = null;
       this.submitMessage = '';
-      this.isLoading = false;
+      this.isLoading = options.loading ?? false;
       this.error = null;
     }
   },

--- a/web/src/stores/essay.ts
+++ b/web/src/stores/essay.ts
@@ -1,6 +1,8 @@
 import { defineStore } from 'pinia';
 import { essayRepository, type EssayHistoryRecord, type EssayLecture } from '@/services/EssayRepository';
 import { essayFlowService, type EssayContext } from '@/services/EssayFlowService';
+import { EssayDraftAutosave } from '@/services/EssayDraftAutosave';
+import type { AgentRunView } from '@/modules/agent/public';
 
 export interface EssayQuestion {
   id: string;
@@ -16,15 +18,31 @@ export interface EssaySubmission {
   isSubmitting: boolean;
 }
 
+/** A past attempt shown read-only, so reviewing one never overwrites the live draft. */
+export interface EssayAttemptPreview {
+  id: string;
+  title: string;
+  content: string;
+  feedback: string;
+  createdAt: number;
+}
+
 export interface EssayState {
   question: EssayQuestion | null;
   submission: EssaySubmission;
   history: EssayHistoryRecord[];
+  preview: EssayAttemptPreview | null;
   context: EssayContext | null;
   submitMessage: string;
   isLoading: boolean;
   error: string | null;
 }
+
+const draftAutosave = new EssayDraftAutosave(
+  (draft, context) => essayRepository.saveDraft(draft, context),
+  180,
+  (cause) => console.warn('[Essay] draft autosave failed', cause)
+);
 
 export const useEssayStore = defineStore('essay', {
   state: (): EssayState => ({
@@ -35,6 +53,7 @@ export const useEssayStore = defineStore('essay', {
       isSubmitting: false,
     },
     history: [],
+    preview: null,
     context: null,
     submitMessage: '',
     isLoading: true,
@@ -45,13 +64,12 @@ export const useEssayStore = defineStore('essay', {
     async fetchQuestion(context: EssayContext) {
       this.isLoading = true;
       this.error = null;
+      // The pending draft belongs to the set being left, so it must land before switching.
+      await draftAutosave.flush();
       try {
         this.context = context;
-        const state = await essayRepository.getState(context);
-        this.question = state.question;
-        this.submission.content = state.draft;
-        this.submission.feedback = state.feedback;
-        this.history = state.history;
+        this.preview = null;
+        this.applyState(await essayRepository.getState(context));
       } catch (error) {
         this.error = error instanceof Error ? error.message : String(error);
       } finally {
@@ -59,38 +77,97 @@ export const useEssayStore = defineStore('essay', {
       }
     },
 
+    /**
+     * Brings grading results in without disturbing the answer being written: the in-memory
+     * draft is authoritative while the page is open, so a background reload never reassigns it.
+     */
+    async refresh() {
+      const context = this.context;
+      if (!context) return;
+      try {
+        await draftAutosave.flush();
+        const state = await essayRepository.getState(context);
+        this.question = state.question;
+        this.submission.feedback = state.feedback;
+        this.history = state.history;
+        this.error = null;
+      } catch (error) {
+        this.error = error instanceof Error ? error.message : String(error);
+      }
+    },
+
+    reportError(cause: unknown) {
+      this.error = cause instanceof Error ? cause.message : String(cause);
+    },
+
     updateContent(content: string) {
       this.submission.content = content;
       this.submission.feedback = null;
       this.submitMessage = '';
-      const context = requireEssayContext(this.context);
-      void essayRepository.saveDraft(content, context);
+      draftAutosave.schedule(content, requireEssayContext(this.context));
     },
 
-    async submitForGrading() {
+    async submitForGrading(): Promise<AgentRunView | undefined> {
       this.submission.isSubmitting = true;
       this.submission.feedback = null;
       this.submitMessage = '';
+      this.error = null;
       try {
-        await essayFlowService.enqueueGrading(this.submission.content, requireEssayContext(this.context));
-        this.submitMessage = '批改任务已提交，可在任务栏查看进度。';
+        const context = requireEssayContext(this.context);
+        await draftAutosave.flush();
+        const result = await essayFlowService.enqueueGrading(this.submission.content, context);
+        this.submitMessage = result.reused
+          ? '本题组已有批改任务在执行，正在等待结果。'
+          : '批改任务已提交，完成后会自动显示。';
+        return result.task;
+      } catch (error) {
+        this.error = error instanceof Error ? error.message : String(error);
+        return undefined;
       } finally {
         this.submission.isSubmitting = false;
       }
     },
 
     async resetDraft() {
-      const state = await essayRepository.resetDraft(requireEssayContext(this.context));
+      // Clearing deliberately throws the pending keystrokes away rather than persisting them.
+      draftAutosave.cancel();
+      try {
+        this.preview = null;
+        this.applyState(await essayRepository.resetDraft(requireEssayContext(this.context)));
+        this.submitMessage = '';
+      } catch (error) {
+        this.error = error instanceof Error ? error.message : String(error);
+      }
+    },
+
+    previewAttempt(item: EssayHistoryRecord) {
+      this.preview = {
+        id: item.id,
+        title: item.title,
+        content: item.content,
+        feedback: item.feedback,
+        createdAt: item.createdAt
+      };
+    },
+
+    closePreview() {
+      this.preview = null;
+    },
+
+    /** Leaves `preview` alone so a background refresh never closes what the reader is reading. */
+    applyState(state: { question: EssayQuestion | null; draft: string; feedback: string | null; history: EssayHistoryRecord[] }) {
+      this.question = state.question;
       this.submission.content = state.draft;
       this.submission.feedback = state.feedback;
       this.history = state.history;
-      this.submitMessage = '';
     },
 
     reset(options: { loading?: boolean } = {}) {
+      void draftAutosave.flush();
       this.question = null;
       this.submission = { content: '', feedback: null, isSubmitting: false };
       this.history = [];
+      this.preview = null;
       this.context = null;
       this.submitMessage = '';
       this.isLoading = options.loading ?? false;

--- a/web/src/views/EssayView.vue
+++ b/web/src/views/EssayView.vue
@@ -106,7 +106,6 @@
         </section>
 
         <template v-else>
-          <div v-if="store.submitMessage" class="submit-message">{{ store.submitMessage }}</div>
           <div v-if="store.submission.feedback" class="feedback-section">
             <h4>AI 批改反馈</h4>
             <MarkdownContent :content="store.submission.feedback" />
@@ -378,9 +377,10 @@ const historyCountLabel = computed(() => (
 ));
 
 async function submitForGrading() {
+  const submittedQuestionSetId = store.context?.questionSetId;
   const run = await store.submitForGrading();
   // A failed enqueue leaves the candidate still answering, so the clock keeps running.
-  if (!run) return;
+  if (!run || !submittedQuestionSetId || store.context?.questionSetId !== submittedQuestionSetId) return;
   pauseTimer();
   isAnswerSheetOpen.value = false;
   trackGrading(run);
@@ -804,7 +804,6 @@ function formatTime(time: number): string {
   line-height: 1.72;
   white-space: pre-wrap;
 }
-.submit-message { padding: 12px 14px; border-radius: var(--radius-card); background: var(--color-brand-soft); color: var(--primary-color); font-size: var(--type-size-secondary); font-weight: var(--type-weight-semibold); }
 .feedback-section { padding: 16px; background: var(--soft-blue); border-radius: var(--radius-card); line-height: 1.7; }
 .feedback-section h4 { margin: 0 0 8px; }
 .feedback-section :deep(p) { margin: 0; }

--- a/web/src/views/EssayView.vue
+++ b/web/src/views/EssayView.vue
@@ -174,9 +174,9 @@
     </BottomSheet>
 
     <BottomSheet v-model="showQuestionHistorySheet" title="历史题目" subtitle="按题型和日期选择" variant="actions">
-      <InfiniteScrollPagination :has-more="questionHistoryVisibleCount < questionHistory.length" :has-items="Boolean(questionHistory.length)" :on-load-more="loadMoreQuestionHistory">
+      <InfiniteScrollPagination :has-more="questionHistoryHasMore" :has-items="Boolean(questionHistory.length)" :on-load-more="loadMoreQuestionHistory">
         <div v-if="questionHistory.length" class="essay-history-list">
-          <button v-for="item in visibleQuestionHistory" :key="item.key" type="button" @click="openQuestionHistoryItem(item)"><span>{{ item.question?.title }}</span><em>{{ item.context.date }} · {{ item.context.topic }}</em>
+          <button v-for="item in questionHistory" :key="item.key" type="button" @click="openQuestionHistoryItem(item)"><span>{{ item.question?.title }}</span><em>{{ item.context.date }} · {{ item.context.topic }}</em>
           </button>
         </div>
       </InfiniteScrollPagination>
@@ -222,8 +222,9 @@ const isAnswerSheetOpen = ref(false);
 const showHistorySheet = ref(false);
 const showQuestionHistorySheet = ref(false);
 const showDeleteConfirmSheet = ref(false);
-const questionHistory = ref<EssayQuestionSetSummary[]>([]); const questionHistoryVisibleCount = ref(20);
-const visibleQuestionHistory = computed(() => questionHistory.value.slice(0, questionHistoryVisibleCount.value));
+const questionHistory = ref<EssayQuestionSetSummary[]>([]);
+const questionHistoryTotal = ref(0);
+const questionHistoryHasMore = computed(() => questionHistory.value.length < questionHistoryTotal.value);
 const answerSheetHeight = ref(42);
 const elapsedMs = ref(0);
 const isTimerRunning = ref(false);
@@ -237,7 +238,7 @@ onMounted(async () => {
   document.addEventListener('visibilitychange', handleVisibilityChange);
   const target = essayQuestionSetTargetFromQuery(route.query);
   if (!target) {
-    store.reset();
+    store.reset({ loading: true });
     await router.replace(essayCenterLocation());
     return;
   }
@@ -306,8 +307,8 @@ async function confirmDeleteCurrentEssay() {
   showDeleteConfirmSheet.value = false;
   isAnswerSheetOpen.value = false;
   activeMode.value = 'lecture';
-  resetTimer();
   if (!store.context) return;
+  resetTimer();
   const state = await essayRepository.deleteState(store.context);
   store.question = state.question;
   store.submission.content = state.draft;
@@ -323,9 +324,19 @@ function openHistoryItem(item: EssayHistoryRecord) {
 }
 
 async function openQuestionHistory() {
-  questionHistory.value = await essayRepository.listStates(); questionHistoryVisibleCount.value = 20; showQuestionHistorySheet.value = true;
+  const [items, total] = await Promise.all([
+    essayRepository.listStates({ limit: 20 }),
+    essayRepository.countStates()
+  ]);
+  questionHistory.value = items;
+  questionHistoryTotal.value = total;
+  showQuestionHistorySheet.value = true;
 }
-function loadMoreQuestionHistory() { questionHistoryVisibleCount.value = Math.min(questionHistory.value.length, questionHistoryVisibleCount.value + 20); }
+async function loadMoreQuestionHistory() {
+  if (!questionHistoryHasMore.value) return;
+  const next = await essayRepository.listStates({ offset: questionHistory.value.length, limit: 20 });
+  questionHistory.value = [...questionHistory.value, ...next];
+}
 async function openQuestionHistoryItem(item: EssayQuestionSetSummary) {
   showQuestionHistorySheet.value = false;
   isAnswerSheetOpen.value = false;

--- a/web/src/views/EssayView.vue
+++ b/web/src/views/EssayView.vue
@@ -5,7 +5,7 @@
         <div class="essay-header-meta">
           <span>{{ essaySessionMeta }}</span>
           <button
-            v-if="activeMode === 'question' && store.question && !store.submission.feedback"
+            v-if="activeMode === 'question' && store.question"
             :class="['essay-session-timer', { running: isTimerRunning }]"
             type="button"
             title="暂停或继续计时"
@@ -33,19 +33,33 @@
       </template>
     </PageHeader>
 
-    <div v-if="store.isLoading" class="loading">加载题目中...</div>
+    <nav v-if="store.question && hasLecture" class="essay-tabs" aria-label="学习内容切换">
+      <button type="button" :class="{ active: activeMode === 'lecture' }" @click="activeMode = 'lecture'">讲义</button>
+      <button type="button" :class="{ active: activeMode === 'question' }" @click="activeMode = 'question'">题目</button>
+    </nav>
 
-    <div v-else-if="store.question" :class="['content-area', 'app-page-scroll', { 'with-start-bar': activeMode === 'question' }]">
-      <div class="mode-tabs">
-        <button type="button" :class="{ active: activeMode === 'lecture' }" @click="activeMode = 'lecture'">讲义</button>
-        <button type="button" :class="{ active: activeMode === 'question' }" @click="activeMode = 'question'">题目</button>
-      </div>
+    <p v-if="gradingStatusText" class="essay-status" role="status">
+      <LoaderCircleIcon />{{ gradingStatusText }}
+    </p>
+    <p v-else-if="pageAlert" class="essay-alert" role="alert">{{ pageAlert }}</p>
 
-      <section v-if="activeMode === 'lecture'" class="lecture-section">
+    <div v-if="store.isLoading" class="app-page-scroll essay-loading" aria-busy="true">
+      <div class="essay-loading-block" aria-hidden="true"></div>
+      <p class="essay-loading-label">正在读取申论题目...</p>
+    </div>
+
+    <section v-else-if="store.error && !store.question" class="essay-empty app-page-scroll">
+      <strong>题目加载失败</strong>
+      <p>{{ store.error }}</p>
+      <button class="essay-retry" type="button" @click="reload">重试</button>
+    </section>
+
+    <div v-else-if="store.question" class="content-area app-page-scroll">
+      <section v-if="activeMode === 'lecture' && activeLecture" class="lecture-section">
         <div class="lecture-head">
-          <span>{{ activeTopic }} · {{ lecture.knowledgePoint || '知识点讲义' }}</span>
-          <h4>{{ lecture.title }}</h4>
-          <p>{{ lecture.summary }}</p>
+          <span>{{ activeTopic }} · {{ activeLecture.knowledgePoint || '知识点讲义' }}</span>
+          <h4>{{ activeLecture.title }}</h4>
+          <p>{{ activeLecture.summary }}</p>
         </div>
         <div class="lecture-grid">
           <article v-for="section in lectureSections" :key="section.title">
@@ -60,6 +74,7 @@
           <div class="question-meta">
             <span>{{ activeTopic }}</span>
             <em>{{ store.context?.date }}</em>
+            <b v-if="hasWordBudget">{{ wordBudgetLabel }}</b>
           </div>
           <h4>{{ store.question.title }}</h4>
           <div class="material-block">
@@ -75,27 +90,36 @@
           </div>
         </div>
 
-        <div v-if="store.submission.isSubmitting" class="feedback-loading">
-          <span class="loading-dot"></span>
-          正在提交批改任务...
-        </div>
+        <section v-if="store.preview" class="attempt-preview">
+          <header>
+            <div>
+              <strong>历史批改</strong>
+              <span>{{ formatTime(store.preview.createdAt) }} · {{ countEssayWords(store.preview.content) }} 字</span>
+            </div>
+            <button type="button" @click="store.closePreview()">返回当前作答</button>
+          </header>
+          <div class="attempt-preview-answer">
+            <strong>当时的作答</strong>
+            <p>{{ store.preview.content }}</p>
+          </div>
+          <MarkdownContent :content="store.preview.feedback" />
+        </section>
 
-        <div v-if="store.submitMessage" class="submit-message">
-          {{ store.submitMessage }}
-        </div>
-
-        <div v-if="store.submission.feedback" class="feedback-section">
-          <h4>AI 批改反馈</h4>
-          <MarkdownContent :content="store.submission.feedback" />
-        </div>
+        <template v-else>
+          <div v-if="store.submitMessage" class="submit-message">{{ store.submitMessage }}</div>
+          <div v-if="store.submission.feedback" class="feedback-section">
+            <h4>AI 批改反馈</h4>
+            <MarkdownContent :content="store.submission.feedback" />
+          </div>
+        </template>
       </template>
 
       <section v-if="store.history.length" class="history-section">
         <div class="history-title">
           <strong>最近批改</strong>
-          <span>最多 10 条</span>
+          <span>{{ historyCountLabel }}</span>
         </div>
-        <article v-for="item in store.history.slice(0, 3)" :key="item.id" class="history-row">
+        <article v-for="item in visibleHistory" :key="item.id" class="history-row">
           <div>
             <strong>{{ item.title }}</strong>
             <span>{{ formatTime(item.createdAt) }} · {{ item.wordCount }} 字<span v-if="item.score"> · {{ item.score }}分</span></span>
@@ -117,12 +141,12 @@
       <p>请返回刷题中心，从私教学习、自主刷题或真题练习入口开始。</p>
     </section>
 
-    <div v-if="store.question && activeMode === 'question' && !isAnswerSheetOpen" class="essay-start-bar">
-      <button type="button" @click="openAnswerSheet">
+    <StickyActionBar v-if="store.question && activeMode === 'question' && !isAnswerSheetOpen">
+      <button class="primary essay-start-button" type="button" @click="openAnswerSheet">
         <Edit3Icon />
         {{ store.submission.content ? '继续作答' : '开始作答' }}
       </button>
-    </div>
+    </StickyActionBar>
 
     <Transition name="answer-backdrop">
       <button v-if="isAnswerSheetOpen" class="answer-backdrop" type="button" aria-label="收起作答区" @click="isAnswerSheetOpen = false"></button>
@@ -153,17 +177,17 @@
           class="answer-textarea"
         ></textarea>
         <footer class="answer-sheet-foot">
-          <span>{{ wordCount }} 字</span>
+          <span :class="['answer-word-count', wordCount.tone]">{{ wordCount.label }}</span>
           <button class="ghost" type="button" @click="store.resetDraft">清空</button>
           <button class="ghost" type="button" @click="isAnswerSheetOpen = false">收起</button>
-          <button class="primary" type="button" :disabled="store.submission.isSubmitting || !store.submission.content" @click="store.submitForGrading">
-            {{ store.submission.isSubmitting ? '批改中...' : '提交批改' }}
+          <button class="primary" type="button" :disabled="store.submission.isSubmitting || !store.submission.content" @click="submitForGrading">
+            {{ store.submission.isSubmitting ? '提交中...' : '提交批改' }}
           </button>
         </footer>
       </section>
     </Transition>
 
-    <BottomSheet v-model="showHistorySheet" title="历史批改" subtitle="最近 10 条记录" variant="actions">
+    <BottomSheet v-model="showHistorySheet" title="历史批改" :subtitle="`共 ${store.history.length} 条`" variant="actions">
       <div v-if="store.history.length" class="essay-history-list">
         <button v-for="item in store.history" :key="item.id" type="button" @click="openHistoryItem(item)">
           <span>{{ item.title }}</span>
@@ -173,10 +197,10 @@
       <div v-else class="sheet-empty">暂无历史批改</div>
     </BottomSheet>
 
-    <BottomSheet v-model="showQuestionHistorySheet" title="历史题目" subtitle="按题型和日期选择" variant="actions">
+    <BottomSheet v-model="showQuestionHistorySheet" title="历史题目" :subtitle="`共 ${questionHistoryTotal} 套`" variant="actions">
       <InfiniteScrollPagination :has-more="questionHistoryHasMore" :has-items="Boolean(questionHistory.length)" :on-load-more="loadMoreQuestionHistory">
         <div v-if="questionHistory.length" class="essay-history-list">
-          <button v-for="item in questionHistory" :key="item.key" type="button" @click="openQuestionHistoryItem(item)"><span>{{ item.question?.title }}</span><em>{{ item.context.date }} · {{ item.context.topic }}</em>
+          <button v-for="item in questionHistory" :key="item.key" type="button" @click="openQuestionHistoryItem(item)"><span>{{ item.question?.title }}</span><em>{{ item.classification === 'legacy_unknown' ? '历史未分类 · ' : '' }}{{ item.context.date }} · {{ item.context.topic }}</em>
           </button>
         </div>
       </InfiniteScrollPagination>
@@ -195,29 +219,55 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, computed, ref } from 'vue';
+import { onMounted, onUnmounted, computed, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { ChevronDownIcon, Clock3Icon, Edit3Icon, FileClockIcon, HistoryIcon, Trash2Icon } from 'lucide-vue-next';
+import { ChevronDownIcon, Clock3Icon, Edit3Icon, FileClockIcon, HistoryIcon, LoaderCircleIcon, Trash2Icon } from 'lucide-vue-next';
 import BottomSheet from '@/components/layout/BottomSheet.vue';
 import ConfirmDialog from '@/components/layout/ConfirmDialog.vue';
 import HeaderMoreMenu from '@/components/layout/HeaderMoreMenu.vue';
 import PageHeader from '@/components/layout/PageHeader.vue';
 import MarkdownContent from '@/components/MarkdownContent.vue';
-import { InfiniteScrollPagination } from '@/capabilities/design-system/public';
-import type { EssayHistoryRecord, EssayLecture, EssayQuestionSetSummary } from '@/services/EssayRepository';
+import { InfiniteScrollPagination, StickyActionBar } from '@/capabilities/design-system/public';
+import { countEssayWords, describeEssayWordCount } from '@/domain/essayAnswer';
+import { splitEssayMaterial, splitEssayRequirement } from '@/domain/essayQuestionText';
+import type { EssayHistoryRecord, EssayQuestionSetSummary } from '@/services/EssayRepository';
 import { essayRepository } from '@/services/EssayRepository';
 import { useEssayStore } from '@/stores/essay';
-import { essayFlowService } from '@/services/EssayFlowService';
+import { essayFlowService, type EssayContext } from '@/services/EssayFlowService';
 import {
   essayCenterLocation,
   essayQuestionSetLocation,
   essayQuestionSetTargetFromQuery
 } from '@/features/practice/EssayNavigation';
+import { useEssayGradingWatcher } from '@/features/practice/useEssayGradingWatcher';
+import { useEssaySessionTimer } from '@/features/practice/useEssaySessionTimer';
+
+const HISTORY_PREVIEW_COUNT = 3;
+const QUESTION_HISTORY_PAGE_SIZE = 20;
 
 const store = useEssayStore();
 const route = useRoute();
 const router = useRouter();
-const activeMode = ref<'lecture' | 'question'>('lecture');
+const {
+  elapsedText,
+  isRunning: isTimerRunning,
+  activate: activateTimer,
+  restore: restoreTimer,
+  start: startTimer,
+  pause: pauseTimer,
+  toggle: toggleTimer,
+  clear: clearTimer
+} = useEssaySessionTimer();
+const {
+  isGrading,
+  progressText: gradingProgress,
+  failure: gradingFailure,
+  track: trackGrading,
+  resume: resumeGrading,
+  stop: stopGrading
+} = useEssayGradingWatcher({ onGraded: () => store.refresh() });
+
+const activeMode = ref<'lecture' | 'question'>('question');
 const isAnswerSheetOpen = ref(false);
 const showHistorySheet = ref(false);
 const showQuestionHistorySheet = ref(false);
@@ -226,43 +276,56 @@ const questionHistory = ref<EssayQuestionSetSummary[]>([]);
 const questionHistoryTotal = ref(0);
 const questionHistoryHasMore = computed(() => questionHistory.value.length < questionHistoryTotal.value);
 const answerSheetHeight = ref(42);
-const elapsedMs = ref(0);
-const isTimerRunning = ref(false);
-let timerId: number | null = null;
-let timerStorageKey: string | null = null;
-let disposed = false;
 let resizeStartY = 0;
 let resizeStartHeight = 0;
+let openedQuestionSetId = '';
 
-onMounted(async () => {
-  document.addEventListener('visibilitychange', handleVisibilityChange);
+onMounted(() => openRouteTarget());
+
+/**
+ * The route can change without remounting — a task card linking to another set reuses this
+ * component — so the query is the source of truth for which set is on screen.
+ */
+watch(() => route.query.questionSetId, () => {
+  const target = essayQuestionSetTargetFromQuery(route.query);
+  if (target && target.questionSetId === openedQuestionSetId) return;
+  void openRouteTarget();
+});
+
+onUnmounted(() => {
+  window.removeEventListener('pointermove', resizeAnswerSheet);
+});
+
+async function openRouteTarget() {
   const target = essayQuestionSetTargetFromQuery(route.query);
   if (!target) {
+    openedQuestionSetId = '';
     store.reset({ loading: true });
     await router.replace(essayCenterLocation());
     return;
   }
-  const routeContext = essayFlowService.writeContext(target);
-  activateTimerOwner(routeContext);
-  await store.fetchQuestion(routeContext);
-  if (disposed) return;
-  restoreTimer();
-});
+  stopGrading();
+  await openContext(essayFlowService.writeContext(target));
+}
 
-onUnmounted(() => {
-  disposed = true;
-  document.removeEventListener('visibilitychange', handleVisibilityChange);
-  window.removeEventListener('pointermove', resizeAnswerSheet);
-  saveTimer();
-  stopTimer();
-});
+async function openContext(context: EssayContext) {
+  openedQuestionSetId = context.questionSetId;
+  isAnswerSheetOpen.value = false;
+  activateTimer(context.questionSetId);
+  await store.fetchQuestion(context);
+  restoreTimer();
+  await resumeGrading(context.questionSetId);
+}
+
+function reload() {
+  return openRouteTarget();
+}
 
 const updateContent = (event: Event) => {
   const target = event.target as HTMLTextAreaElement;
   store.updateContent(target.value);
 };
 
-const wordCount = computed(() => store.submission.content.length);
 const activeTopic = computed(() => store.context?.topic || '申论练习');
 const essayHeaderTitle = computed(() => `申论 · ${activeTopic.value}`);
 const essaySessionMeta = computed(() => {
@@ -272,83 +335,116 @@ const essaySessionMeta = computed(() => {
       ? '真题练习'
       : '自主刷题';
   if (activeMode.value === 'lecture') return `${mode} · 配套讲义`;
+  if (store.preview) return `${mode} · 历史回顾`;
   if (store.submission.feedback) return `${mode} · 批改结果`;
   return `${mode} · ${store.submission.content ? '继续作答' : '未作答'}`;
 });
-const isLongEssay = computed(() => store.context?.type === 'long' || activeTopic.value === '申发论述');
-const lecture = computed<EssayLecture>(() => store.question?.lecture || {
-  knowledgePoint: activeTopic.value,
-  title: '暂无知识点讲义',
-  summary: '生成申论练习后，会同时生成一份围绕细分知识点的学习讲义，并让题目材料和作答要求服务于这个训练目标。',
-  clues: [],
-  methods: [],
-  structure: [],
-  warnings: [],
-  cases: [],
-  drills: []
+const gradingStatusText = computed(() => {
+  if (store.submission.isSubmitting) return '正在提交批改任务...';
+  if (isGrading.value) return gradingProgress.value || '正在批改，完成后会自动显示';
+  return '';
 });
-const lectureSections = computed(() => [
-  { title: '审题抓手', items: lecture.value.clues },
-  { title: '核心方法', items: lecture.value.methods },
-  { title: '作答结构', items: lecture.value.structure },
-  { title: '易错提醒', items: lecture.value.warnings },
-  { title: '规范表达', items: lecture.value.cases },
-  { title: '训练任务', items: lecture.value.drills }
-].filter((section) => section.items.length > 0));
-const elapsedText = computed(() => formatDuration(elapsedMs.value));
-const materialParagraphs = computed(() => splitMaterial(store.question?.material || ''));
-const requirementTasks = computed(() => splitRequirement(store.question?.requirement || ''));
+const pageAlert = computed(() => gradingFailure.value || (store.question ? store.error || '' : ''));
+const isLongEssay = computed(() => store.context?.type === 'long' || activeTopic.value === '申发论述');
+const activeLecture = computed(() => store.question?.lecture);
+const lectureSections = computed(() => {
+  const lecture = activeLecture.value;
+  if (!lecture) return [];
+  return [
+    { title: '审题抓手', items: lecture.clues },
+    { title: '核心方法', items: lecture.methods },
+    { title: '作答结构', items: lecture.structure },
+    { title: '易错提醒', items: lecture.warnings },
+    { title: '规范表达', items: lecture.cases },
+    { title: '训练任务', items: lecture.drills }
+  ].filter((section) => section.items?.length);
+});
+const hasLecture = computed(() => Boolean(activeLecture.value?.title || lectureSections.value.length));
+const materialParagraphs = computed(() => splitEssayMaterial(store.question?.material || ''));
+const requirementTasks = computed(() => splitEssayRequirement(store.question?.requirement || ''));
+const wordCount = computed(() => describeEssayWordCount(store.submission.content, store.question?.requirement || ''));
+const hasWordBudget = computed(() => Boolean(wordCount.value.limit.max || wordCount.value.limit.min));
+const wordBudgetLabel = computed(() => {
+  const { min, max } = wordCount.value.limit;
+  if (min && max) return `${min}–${max} 字`;
+  if (max) return `不超过 ${max} 字`;
+  return `不少于 ${min} 字`;
+});
+const visibleHistory = computed(() => store.history.slice(0, HISTORY_PREVIEW_COUNT));
+const historyCountLabel = computed(() => (
+  store.history.length > HISTORY_PREVIEW_COUNT
+    ? `最近 ${HISTORY_PREVIEW_COUNT} 条 · 共 ${store.history.length} 条`
+    : `共 ${store.history.length} 条`
+));
 
-async function deleteCurrentEssay() {
+async function submitForGrading() {
+  const run = await store.submitForGrading();
+  // A failed enqueue leaves the candidate still answering, so the clock keeps running.
+  if (!run) return;
+  pauseTimer();
+  isAnswerSheetOpen.value = false;
+  trackGrading(run);
+}
+
+function deleteCurrentEssay() {
   showDeleteConfirmSheet.value = true;
 }
 
 async function confirmDeleteCurrentEssay() {
   showDeleteConfirmSheet.value = false;
+  const context = store.context;
+  if (!context) return;
   isAnswerSheetOpen.value = false;
-  activeMode.value = 'lecture';
-  if (!store.context) return;
-  resetTimer();
-  const state = await essayRepository.deleteState(store.context);
-  store.question = state.question;
-  store.submission.content = state.draft;
-  store.submission.feedback = state.feedback;
-  store.history = state.history;
+  activeMode.value = 'question';
+  stopGrading();
+  clearTimer();
+  try {
+    store.applyState(await essayRepository.deleteState(context));
+    store.closePreview();
+  } catch (cause) {
+    store.reportError(cause);
+  }
 }
 
 function openHistoryItem(item: EssayHistoryRecord) {
   showHistorySheet.value = false;
   activeMode.value = 'question';
-  store.submission.content = item.content;
-  store.submission.feedback = item.feedback;
+  store.previewAttempt(item);
 }
 
 async function openQuestionHistory() {
-  const [items, total] = await Promise.all([
-    essayRepository.listStates({ limit: 20 }),
-    essayRepository.countStates()
-  ]);
-  questionHistory.value = items;
-  questionHistoryTotal.value = total;
-  showQuestionHistorySheet.value = true;
+  try {
+    const [items, total] = await Promise.all([
+      essayRepository.listStates({ limit: QUESTION_HISTORY_PAGE_SIZE }),
+      essayRepository.countStates()
+    ]);
+    questionHistory.value = items;
+    questionHistoryTotal.value = total;
+    showQuestionHistorySheet.value = true;
+  } catch (cause) {
+    store.reportError(cause);
+  }
 }
+
 async function loadMoreQuestionHistory() {
   if (!questionHistoryHasMore.value) return;
-  const next = await essayRepository.listStates({ offset: questionHistory.value.length, limit: 20 });
-  questionHistory.value = [...questionHistory.value, ...next];
+  try {
+    const next = await essayRepository.listStates({
+      offset: questionHistory.value.length,
+      limit: QUESTION_HISTORY_PAGE_SIZE
+    });
+    questionHistory.value = [...questionHistory.value, ...next];
+  } catch (cause) {
+    store.reportError(cause);
+  }
 }
+
 async function openQuestionHistoryItem(item: EssayQuestionSetSummary) {
   showQuestionHistorySheet.value = false;
-  isAnswerSheetOpen.value = false;
-  activeMode.value = 'lecture';
+  activeMode.value = 'question';
+  stopGrading();
   const context = essayFlowService.writeContext(item.context);
-  saveTimer();
-  stopTimer();
-  elapsedMs.value = 0;
-  activateTimerOwner(context);
-  await store.fetchQuestion(context);
-  if (disposed) return;
-  restoreTimer();
+  await openContext(context);
   await router.replace(essayQuestionSetLocation({
     questionSetId: context.questionSetId,
     entryMode: context.entryMode,
@@ -361,6 +457,7 @@ async function openQuestionHistoryItem(item: EssayQuestionSetSummary) {
 
 function openAnswerSheet() {
   activeMode.value = 'question';
+  store.closePreview();
   answerSheetHeight.value = isLongEssay.value ? 62 : 42;
   isAnswerSheetOpen.value = true;
   startTimer();
@@ -393,108 +490,6 @@ function formatTime(time: number): string {
   });
 }
 
-function formatDuration(ms: number): string {
-  const seconds = Math.max(0, Math.floor(ms / 1000));
-  const minutes = Math.floor(seconds / 60);
-  return `${String(minutes).padStart(2, '0')}:${String(seconds % 60).padStart(2, '0')}`;
-}
-
-function splitMaterial(material: string): string[] {
-  const clean = material.trim();
-  if (!clean) return [];
-  const normalized = clean.replace(/^给定资料[:：]\s*/u, '');
-  return normalized
-    .split(/\n{2,}|(?=材料[一二三四五六七八九十\d]+[:：])|(?=资料[一二三四五六七八九十\d]+[:：])/u)
-    .map((item) => item.trim())
-    .filter(Boolean);
-}
-
-function splitRequirement(requirement: string): string[] {
-  const clean = requirement.trim().replace(/^要求[:：]\s*/u, '');
-  if (!clean) return [];
-  const parts = clean
-    .split(/(?:\n+|(?=[（(]?\d+[）).、])|(?=[一二三四五六七八九十]+[、.．]))/u)
-    .map((item) => item.replace(/^[（(]?\d+[）).、]\s*/u, '').replace(/^[一二三四五六七八九十]+[、.．]\s*/u, '').trim())
-    .filter(Boolean);
-  return parts.length ? parts : [clean];
-}
-
-function activateTimerOwner(context: { questionSetId: string }) {
-  timerStorageKey = `essay-timer:${context.questionSetId}`;
-}
-
-function restoreTimer() {
-  if (!timerStorageKey) return;
-  try {
-    const raw = localStorage.getItem(timerStorageKey);
-    if (!raw) return;
-    const saved = JSON.parse(raw) as { elapsedMs?: number; running?: boolean; savedAt?: number };
-    elapsedMs.value = saved.elapsedMs || 0;
-    if (saved.running && saved.savedAt) {
-      elapsedMs.value += Date.now() - saved.savedAt;
-      startTimer();
-    }
-  } catch {
-    elapsedMs.value = 0;
-  }
-}
-
-function saveTimer() {
-  if (!timerStorageKey) return;
-  localStorage.setItem(timerStorageKey, JSON.stringify({
-    elapsedMs: elapsedMs.value,
-    running: isTimerRunning.value,
-    savedAt: Date.now()
-  }));
-}
-
-function startTimer() {
-  if (timerId !== null) return;
-  isTimerRunning.value = true;
-  const startedAt = Date.now() - elapsedMs.value;
-  timerId = window.setInterval(() => {
-    elapsedMs.value = Date.now() - startedAt;
-    if (Math.floor(elapsedMs.value / 1000) % 10 === 0) saveTimer();
-  }, 1000);
-  saveTimer();
-}
-
-function stopTimer() {
-  if (timerId !== null) {
-    window.clearInterval(timerId);
-    timerId = null;
-  }
-  isTimerRunning.value = false;
-}
-
-function toggleTimer() {
-  if (isTimerRunning.value) {
-    stopTimer();
-    saveTimer();
-  } else {
-    startTimer();
-  }
-}
-
-function resetTimer() {
-  stopTimer();
-  elapsedMs.value = 0;
-  try {
-    if (timerStorageKey) localStorage.removeItem(timerStorageKey);
-  } catch {
-    // ignore storage failures
-  }
-}
-
-function handleVisibilityChange() {
-  if (document.hidden) {
-    saveTimer();
-    stopTimer();
-  } else {
-    restoreTimer();
-  }
-}
-
 </script>
 
 <style scoped>
@@ -519,23 +514,110 @@ function handleVisibilityChange() {
   align-items: center;
   gap: 3px;
   border: none;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 0 6px;
   background: rgba(var(--color-ink-rgb), .045);
   color: var(--text-secondary-color);
+  font: inherit;
   font-size: var(--type-size-micro);
   font-weight: var(--type-weight-semibold);
   font-variant-numeric: tabular-nums;
-  font-family: inherit;
 }
 .essay-session-timer.running {
-  background: rgba(var(--color-brand-rgb), .1);
+  background: var(--color-brand-soft);
   color: var(--primary-color);
 }
 .essay-session-timer svg { width: 12px; height: 12px; }
+.essay-tabs {
+  flex-shrink: 0;
+  align-self: center;
+  display: flex;
+  gap: 3px;
+  margin: 6px auto 0;
+  padding: 3px;
+  border-radius: var(--radius-pill);
+  background: rgba(var(--color-ink-rgb), .055);
+}
+.essay-tabs button {
+  min-width: 74px;
+  height: 30px;
+  border: none;
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary-color);
+  background: transparent;
+  font: inherit;
+  font-size: var(--type-size-caption);
+  font-weight: var(--type-weight-semibold);
+}
+.essay-tabs button.active {
+  color: var(--text-color);
+  background: var(--surface-card-strong);
+  box-shadow: 0 1px 5px rgba(var(--color-ink-rgb), .08);
+}
+.essay-status,
+.essay-alert {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 8px 0 0;
+  padding: 9px 11px;
+  border-radius: var(--radius-control);
+  font-size: var(--type-size-caption);
+  font-weight: var(--type-weight-semibold);
+}
+.essay-status {
+  color: var(--primary-color);
+  background: var(--color-brand-soft);
+}
+.essay-status svg {
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+  animation: essaySpin 1.1s linear infinite;
+}
+.essay-alert {
+  color: var(--red-color);
+  background: var(--color-danger-soft);
+}
+.essay-loading {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 12px;
+}
+.essay-loading-block {
+  min-height: 280px;
+  border-radius: var(--radius-card);
+  background: linear-gradient(
+    rgba(var(--color-ink-rgb), .09) 0 18px, transparent 18px 30px,
+    rgba(var(--color-ink-rgb), .07) 30px 48px, transparent 48px 64px,
+    rgba(var(--color-ink-rgb), .055) 64px 132px, transparent 132px 148px,
+    rgba(var(--color-ink-rgb), .055) 148px 216px, transparent 216px
+  );
+  animation: essayLoadingPulse 1.25s ease-in-out infinite;
+}
+.essay-loading-label {
+  margin: 0;
+  color: var(--text-secondary-color);
+  font-size: var(--type-size-caption);
+  text-align: center;
+}
 .essay-empty { min-height: 320px; display: grid; place-content: center; gap: 8px; padding: 30px 18px; text-align: center; color: var(--text-secondary-color); }
-.essay-empty strong { color: var(--text-color); font-size: var(--type-size-title); }
+.essay-empty strong { color: var(--text-color); font-size: var(--type-size-section-title); }
 .essay-empty p { margin: 0; line-height: 1.6; }
+.essay-retry {
+  justify-self: center;
+  min-height: 38px;
+  margin-top: 4px;
+  border: none;
+  border-radius: var(--radius-control);
+  padding: 0 18px;
+  color: var(--primary-color);
+  background: var(--color-brand-soft);
+  font: inherit;
+  font-weight: var(--type-weight-semibold);
+}
 .content-area {
   flex: 1;
   overflow-y: auto;
@@ -544,39 +626,12 @@ function handleVisibilityChange() {
   gap: 10px;
   padding-bottom: 10px;
 }
-.content-area.with-start-bar {
-  padding-bottom: 78px;
-}
-.mode-tabs {
-  padding: 3px;
-  border-radius: 11px;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 3px;
-  background: rgba(var(--color-ink-rgb), .06);
-  flex-shrink: 0;
-}
-.mode-tabs button {
-  height: 32px;
-  border: none;
-  border-radius: 9px;
-  color: var(--text-secondary-color);
-  background: transparent;
-  font-family: inherit;
-  font-size: var(--type-size-secondary);
-  font-weight: var(--type-weight-semibold);
-}
-.mode-tabs button.active {
-  color: var(--primary-color);
-  background: rgba(255, 255, 255, .9);
-  box-shadow: 0 1px 5px rgba(28, 38, 58, .08);
-}
 .lecture-section {
   padding: 13px;
-  border-radius: 14px;
-  background: rgba(255,255,255,.82);
-  border: 1px solid rgba(var(--color-ink-rgb), .06);
-  box-shadow: 0 10px 26px rgba(28,38,58,.06);
+  border-radius: var(--radius-card);
+  background: var(--surface-card-strong);
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-card);
 }
 .lecture-head {
   display: flex;
@@ -607,11 +662,11 @@ function handleVisibilityChange() {
 }
 .lecture-grid article {
   padding: 10px 11px;
-  border-radius: 12px;
+  border-radius: var(--radius-card);
   display: flex;
   flex-direction: column;
   gap: 5px;
-  background: rgba(var(--color-ink-rgb), .045);
+  background: var(--surface-muted);
 }
 .lecture-grid strong {
   color: var(--text-color);
@@ -623,33 +678,13 @@ function handleVisibilityChange() {
   font-style: normal;
   line-height: 1.48;
 }
-.start-answer-btn {
-  width: 100%;
-  min-height: 42px;
-  margin-top: 14px;
-  border: none;
-  border-radius: 12px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 7px;
-  background: var(--primary-color);
-  color: #fff;
-  font-family: inherit;
-  font-size: var(--type-size-body);
-  font-weight: var(--type-weight-semibold);
-}
-.start-answer-btn svg {
-  width: 16px;
-  height: 16px;
-}
 .question-section {
   margin: 0;
   padding: 13px 14px;
-  border-radius: 14px;
-  background: rgba(255,255,255,.84);
-  border: 1px solid rgba(var(--color-ink-rgb), .06);
-  box-shadow: 0 10px 26px rgba(28,38,58,.07);
+  border-radius: var(--radius-card);
+  background: var(--surface-card-strong);
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-card);
 }
 .question-meta {
   display: flex;
@@ -659,17 +694,24 @@ function handleVisibilityChange() {
 }
 .question-meta span {
   padding: 3px 9px;
-  border-radius: 999px;
-  background: rgba(var(--color-brand-rgb), .1);
+  border-radius: var(--radius-pill);
+  background: var(--color-brand-soft);
   color: var(--primary-color);
   font-size: var(--type-size-micro);
   font-weight: var(--type-weight-semibold);
 }
-.question-meta em {
+.question-meta em,
+.question-meta b {
   color: var(--text-secondary-color);
   font-size: var(--type-size-micro);
   font-style: normal;
   font-weight: var(--type-weight-semibold);
+}
+.question-meta b {
+  margin-left: auto;
+  padding: 3px 8px;
+  border-radius: var(--radius-pill);
+  background: var(--surface-muted);
 }
 .question-section h4 {
   margin: 0 0 8px;
@@ -680,8 +722,8 @@ function handleVisibilityChange() {
 .requirement-block {
   margin-top: 10px;
   padding: 11px;
-  border-radius: 12px;
-  background: rgba(245, 246, 250, .72);
+  border-radius: var(--radius-card);
+  background: var(--surface-muted);
 }
 .material-block strong,
 .requirement-block strong {
@@ -701,7 +743,7 @@ function handleVisibilityChange() {
 .material-block p + p {
   margin-top: 9px;
   padding-top: 9px;
-  border-top: 1px dashed rgba(var(--color-ink-rgb), .08);
+  border-top: 1px dashed var(--border-control);
 }
 .requirement-block ol {
   margin: 0;
@@ -710,17 +752,67 @@ function handleVisibilityChange() {
 .requirement-block li + li {
   margin-top: 6px;
 }
-.feedback-loading { display: flex; align-items: center; justify-content: center; gap: 8px; padding: 18px; font-size: var(--type-size-body-large); color: var(--primary-color); }
-.submit-message { margin-top: 14px; padding: 12px 14px; border-radius: 13px; background: rgba(var(--color-brand-rgb), .1); color: var(--primary-color); font-size: var(--type-size-secondary); font-weight: var(--type-weight-semibold); }
-.loading-dot { width: 9px; height: 9px; border-radius: 999px; background: var(--primary-color); animation: essayPulse 1s ease-in-out infinite; }
-.feedback-section { margin-top: 16px; padding: 16px; background: var(--soft-blue); border-radius: 14px; line-height: 1.7; }
+.attempt-preview {
+  padding: 13px 14px;
+  border-radius: var(--radius-card);
+  border: 1px solid var(--border-control);
+  background: var(--surface-card);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.attempt-preview header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.attempt-preview header div {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.attempt-preview header strong { font-size: var(--type-size-secondary); }
+.attempt-preview header span { color: var(--text-secondary-color); font-size: var(--type-size-micro); }
+.attempt-preview header button {
+  flex: 0 0 auto;
+  min-height: 30px;
+  border: none;
+  border-radius: var(--radius-pill);
+  padding: 0 11px;
+  color: var(--primary-color);
+  background: var(--color-brand-soft);
+  font: inherit;
+  font-size: var(--type-size-caption);
+  font-weight: var(--type-weight-semibold);
+}
+.attempt-preview-answer {
+  padding: 11px;
+  border-radius: var(--radius-card);
+  background: var(--surface-muted);
+}
+.attempt-preview-answer strong {
+  display: block;
+  margin-bottom: 6px;
+  font-size: var(--type-size-secondary);
+}
+.attempt-preview-answer p {
+  margin: 0;
+  color: var(--text-secondary-color);
+  font-size: var(--type-size-body);
+  line-height: 1.72;
+  white-space: pre-wrap;
+}
+.submit-message { padding: 12px 14px; border-radius: var(--radius-card); background: var(--color-brand-soft); color: var(--primary-color); font-size: var(--type-size-secondary); font-weight: var(--type-weight-semibold); }
+.feedback-section { padding: 16px; background: var(--soft-blue); border-radius: var(--radius-card); line-height: 1.7; }
 .feedback-section h4 { margin: 0 0 8px; }
 .feedback-section :deep(p) { margin: 0; }
-.history-section { margin-top: 16px; padding: 14px; border: 1px solid rgba(var(--color-ink-rgb), .06); border-radius: 14px; background: rgba(255,255,255,.82); box-shadow: 0 10px 26px rgba(28,38,58,.06); }
+.history-section { padding: 14px; border: 1px solid var(--border-subtle); border-radius: var(--radius-card); background: var(--surface-card-strong); box-shadow: var(--shadow-card); }
 .history-title { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
 .history-title strong { font-size: var(--type-size-body-large); }
 .history-title span { color: var(--text-secondary-color); font-size: var(--type-size-micro); font-weight: var(--type-weight-semibold); }
-.history-row { padding: 10px 0; border-top: 1px solid rgba(var(--color-ink-rgb), .06); }
+.history-row { padding: 10px 0; border-top: 1px solid var(--border-subtle); }
 .history-row:first-of-type { border-top: none; padding-top: 0; }
 .history-row div { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
 .history-row strong { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: var(--type-size-secondary); }
@@ -731,34 +823,16 @@ function handleVisibilityChange() {
 .dimension-list b { color: var(--text-color); }
 .dimension-list em { font-style: normal; color: var(--primary-color); font-weight: var(--type-weight-semibold); }
 .dimension-list span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.essay-start-bar {
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 50;
-  padding: 8px var(--page-x) calc(8px + env(safe-area-inset-bottom));
-  background:
-    linear-gradient(180deg, rgba(247, 249, 252, 0), rgba(247, 249, 252, .94) 22%, rgba(247, 249, 252, .98));
-  box-shadow: 0 -10px 24px rgba(28,38,58,.06);
-}
-.essay-start-bar button {
-  width: 100%;
-  height: 50px;
-  border: none;
-  border-radius: 14px;
+.essay-start-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  background: var(--primary-color);
-  color: #fff;
-  font-family: inherit;
+  min-height: 50px;
   font-size: var(--type-size-control);
   font-weight: var(--type-weight-semibold);
-  box-shadow: 0 8px 18px rgba(var(--color-brand-rgb), .18);
 }
-.essay-start-bar svg {
+.essay-start-button svg {
   width: 18px;
   height: 18px;
 }
@@ -767,7 +841,7 @@ function handleVisibilityChange() {
   inset: 0;
   z-index: 70;
   border: none;
-  background: rgba(15, 23, 42, .34);
+  background: var(--app-overlay-bg);
   padding: 0;
 }
 .answer-sheet {
@@ -776,11 +850,11 @@ function handleVisibilityChange() {
   right: 0;
   bottom: 0;
   z-index: 71;
-  border-radius: 18px 18px 0 0;
+  border-radius: var(--radius-sheet) var(--radius-sheet) 0 0;
   display: flex;
   flex-direction: column;
   background: var(--app-sheet-bg);
-  box-shadow: 0 -18px 50px rgba(15, 23, 42, .24);
+  box-shadow: var(--shadow-dialog);
   overflow: hidden;
 }
 .answer-handle {
@@ -795,7 +869,7 @@ function handleVisibilityChange() {
   content: '';
   width: 36px;
   height: 4px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: rgba(var(--color-ink-rgb), .16);
 }
 .answer-sheet-head {
@@ -813,7 +887,7 @@ function handleVisibilityChange() {
 .answer-dot {
   width: 8px;
   height: 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: var(--primary-color);
 }
 .answer-sheet-head strong {
@@ -824,7 +898,7 @@ function handleVisibilityChange() {
   width: 30px;
   height: 30px;
   border: none;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -844,7 +918,7 @@ function handleVisibilityChange() {
   padding: 2px 16px 10px;
   background: transparent;
   color: var(--text-color);
-  font-family: inherit;
+  font: inherit;
   font-size: var(--type-size-body-large);
   line-height: 1.85;
   resize: none;
@@ -861,31 +935,34 @@ function handleVisibilityChange() {
   align-items: center;
   gap: 8px;
   padding: 9px 14px calc(9px + env(safe-area-inset-bottom));
-  border-top: 1px solid rgba(var(--color-ink-rgb), .06);
+  border-top: 1px solid var(--border-subtle);
 }
-.answer-sheet-foot span {
+.answer-word-count {
   min-width: 44px;
   color: var(--text-secondary-color);
   font-size: var(--type-size-caption);
   font-weight: var(--type-weight-semibold);
+  font-variant-numeric: tabular-nums;
 }
+.answer-word-count.warning { color: var(--orange-color); }
+.answer-word-count.danger { color: var(--red-color); }
 .answer-sheet-foot button {
   height: 38px;
   border: none;
-  border-radius: 10px;
+  border-radius: var(--radius-control);
   padding: 0 13px;
-  font-family: inherit;
+  font: inherit;
   font-size: var(--type-size-secondary);
   font-weight: var(--type-weight-semibold);
 }
 .answer-sheet-foot .ghost {
-  background: rgba(var(--color-ink-rgb), .06);
+  background: var(--surface-control);
   color: var(--text-secondary-color);
 }
 .answer-sheet-foot .primary {
   flex: 1;
   background: var(--primary-color);
-  color: #fff;
+  color: var(--color-text-inverse);
 }
 .answer-sheet-foot .primary:disabled {
   opacity: .48;
@@ -899,15 +976,15 @@ function handleVisibilityChange() {
   width: 100%;
   min-height: 52px;
   border: none;
-  border-radius: 13px;
+  border-radius: var(--radius-card);
   display: flex;
   flex-direction: column;
   justify-content: center;
   gap: 4px;
   padding: 8px 12px;
-  background: rgba(255,255,255,.74);
+  background: var(--surface-card);
   color: var(--text-color);
-  font-family: inherit;
+  font: inherit;
   text-align: left;
 }
 .essay-history-list span,
@@ -936,7 +1013,7 @@ function handleVisibilityChange() {
 }
 .answer-backdrop-enter-active,
 .answer-backdrop-leave-active {
-  transition: opacity .18s ease;
+  transition: opacity var(--motion-fast) ease;
 }
 .answer-backdrop-enter-from,
 .answer-backdrop-leave-to {
@@ -944,11 +1021,12 @@ function handleVisibilityChange() {
 }
 .answer-sheet-enter-active,
 .answer-sheet-leave-active {
-  transition: transform .22s ease;
+  transition: transform var(--motion-normal) ease;
 }
 .answer-sheet-enter-from,
 .answer-sheet-leave-to {
   transform: translateY(100%);
 }
-@keyframes essayPulse { 0%, 100% { opacity: 1; transform: scale(1); } 50% { opacity: .45; transform: scale(1.35); } }
+@keyframes essaySpin { to { transform: rotate(360deg); } }
+@keyframes essayLoadingPulse { 50% { opacity: .48; } }
 </style>

--- a/web/src/views/ExamView.vue
+++ b/web/src/views/ExamView.vue
@@ -53,14 +53,14 @@
       <section class="history-section">
         <div class="section-title">
           <strong>我的模考记录</strong>
-          <span>最近 30 条</span>
+          <span>{{ stats.total ? `共 ${stats.total} 条` : '暂无记录' }}</span>
         </div>
 
         <AppStateView v-if="isLoading" compact state="loading" title="加载模考记录" />
         <AppStateView v-else-if="!history.length" compact :title="`还没有${subject}模考记录`" description="完成一次模考后，成绩会自动回流到这里。">
           <template #icon><BookOpenIcon /></template>
         </AppStateView>
-        <InfiniteScrollPagination v-else :has-more="historyVisibleCount < history.length" :has-items="Boolean(history.length)" :on-load-more="loadMoreHistory">
+        <InfiniteScrollPagination v-else :has-more="historyVisibleCount < history.length || (subject === '申论' && history.length < stats.total)" :has-items="Boolean(history.length)" :on-load-more="loadMoreHistory">
         <div class="history-groups">
           <div v-for="group in groupedHistory" :key="group.month" class="history-group">
             <div class="month-label">
@@ -176,6 +176,7 @@ import BottomSheet from '@/components/layout/BottomSheet.vue';
 import { AppStateView, InfiniteScrollPagination, PullToRefresh } from '@/capabilities/design-system/public';
 import { practiceDetailLocation } from '@/features/practice/PracticeNavigation';
 import { essayHistoryLocation } from '@/features/practice/EssayNavigation';
+import { durationText, groupHistoryByMonth } from '@/features/exam/ExamHistoryPresentation';
 const router = useRouter();
 const subjects: ExamSubject[] = ['行测', '申论'];
 const initial = examFlowService.readContext();
@@ -217,7 +218,16 @@ async function loadDashboard() {
     isLoading.value = false;
   }
 }
-function loadMoreHistory() { historyVisibleCount.value = Math.min(history.value.length, historyVisibleCount.value + 30); }
+async function loadMoreHistory() {
+  if (historyVisibleCount.value < history.value.length) {
+    historyVisibleCount.value = Math.min(history.value.length, historyVisibleCount.value + 30);
+    return;
+  }
+  if (subject.value !== '申论' || !dashboard.value || history.value.length >= stats.value.total) return;
+  const next = await examFlowService.listEssayMockHistory(history.value.length, 30);
+  dashboard.value = { ...dashboard.value, history: [...dashboard.value.history, ...next] };
+  historyVisibleCount.value = dashboard.value.history.length;
+}
 async function switchSubject(next: ExamSubject) {
   if (subject.value === next) return;
   subject.value = next;
@@ -284,33 +294,6 @@ function openHistory(item: ExamHistoryItem) {
   router.push(practiceDetailLocation({ mode: 'self' }));
 }
 
-function durationText(durationMs?: number): string {
-  if (!durationMs) return '未记录时长';
-  return `${Math.max(1, Math.round(durationMs / 60000))} 分钟`;
-}
-
-function monthKey(date: string): string {
-  return /^\d{4}-\d{2}/.test(date) ? date.slice(0, 7) : 'unknown';
-}
-
-function monthLabel(month: string): string {
-  if (month === 'unknown') return '未记录月份';
-  const [year, value] = month.split('-');
-  return `${year}年${Number(value)}月`;
-}
-
-function groupHistoryByMonth(items: ExamHistoryItem[]): Array<{ month: string; label: string; items: ExamHistoryItem[] }> {
-  const grouped = new Map<string, ExamHistoryItem[]>();
-  items.forEach((item) => {
-    const key = monthKey(item.date);
-    grouped.set(key, [...(grouped.get(key) || []), item]);
-  });
-  return Array.from(grouped.entries()).map(([month, groupItems]) => ({
-    month,
-    label: monthLabel(month),
-    items: groupItems
-  }));
-}
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- promote essay question-set purpose to indexed learning-asset metadata
- isolate practice, true-question, and mock histories at the repository query boundary
- paginate essay histories without repeated IndexedDB full-table scans
- quarantine ambiguous legacy records and terminate incompatible old grade jobs clearly
- remove dead essay repository writes and fix invalid-route timer/loading behavior

## Verification
- `npm run build`
- `npm run check:essay-question-sets`
- `npm run check:sqlite-migrations`
- `npm run typecheck`

Closes #20