### PR TITLE
fix(content): stabilize structured rendering and lecture lifecycle

### DIFF
--- a/scripts/probe-live-generation.mjs
+++ b/scripts/probe-live-generation.mjs
@@ -119,7 +119,7 @@ try {
     ai.structuredObjectivePromptV2.version
   );
   const coreSystem = corePolicy.practiceCoreSystem(coreCompiled.system, capability.code);
-  const coreSchema = corePolicy.practiceCoreResponseSchema(coreCompiled.responseSchema);
+  const coreSchema = corePolicy.practiceCoreResponseSchema(coreCompiled.responseSchema, undefined, capability.code);
   const coreRequestSystem = structuredMode === 'prompt'
     ? appendStructuredOutputContract(coreSystem, coreSchema)
     : coreSystem;

--- a/scripts/verify-content-schema.mjs
+++ b/scripts/verify-content-schema.mjs
@@ -108,6 +108,36 @@ try {
   assert.equal(emptyTable.ok, false);
   assert(emptyTable.error.issues.some((issue) => issue.code === 'content.table_rows_invalid'));
 
+  const validChart = validator.parseDocument({
+    schemaVersion: 'content.v1',
+    blocks: [{
+      id: 'chart',
+      type: 'statistical_chart',
+      chartType: 'combo',
+      title: '产值与增速',
+      unit: '亿元 / %',
+      categories: ['2023', '2024', '2025'],
+      series: [
+        { id: 'output', label: '产值', renderAs: 'bar', values: [1080, 1200, 1290] },
+        { id: 'growth', label: '增速', renderAs: 'line', values: [5.1, 6.2, 7.5] }
+      ]
+    }]
+  });
+  assert.equal(validChart.ok, true);
+
+  const invalidChart = validator.parseDocument({
+    schemaVersion: 'content.v1',
+    blocks: [{
+      id: 'chart',
+      type: 'statistical_chart',
+      chartType: 'bar',
+      categories: ['2024', '2025'],
+      series: [{ id: 'output', label: '产值', values: [1200] }]
+    }]
+  });
+  assert.equal(invalidChart.ok, false);
+  assert(invalidChart.error.issues.some((issue) => issue.code === 'content.chart_values_invalid'));
+
   const invalidSvg = validator.parseDocument({
     schemaVersion: 'content.v1',
     blocks: [{ id: 'diagram', type: 'svg_diagram', markup: '<path d="M0 0" />', alt: '缺少画布的图形' }]
@@ -147,6 +177,86 @@ try {
     rendering.resolveImageSource('javascript:alert(1)').kind,
     rendering.ImageSourceKind.Blocked
   );
+
+  // CommonMark accepts only ASCII space and tab as leading whitespace. One
+  // invisible character in front of a line switches off every block construct
+  // at once and the document renders as a single paragraph — the exact failure
+  // that made generated lectures look as though Markdown had never run.
+  const invisibleLeaders = {
+    'U+00A0': ' ',
+    'U+3000': '　',
+    'U+FEFF': '﻿',
+    'U+200B': '​',
+    'U+2007': ' '
+  };
+  const blockSample = '## 标题\n\n正文。\n\n> 引用\n\n- 列表项';
+  for (const [label, leader] of Object.entries(invisibleLeaders)) {
+    const prefixed = blockSample.split('\n').map((line) => (line ? leader + line : line)).join('\n');
+    const normalizedInvisible = rendering.normalizeMarkdownSource(prefixed);
+    assert.match(normalizedInvisible, /^## 标题$/m, `${label} must not disable ATX headings`);
+    assert.match(normalizedInvisible, /^> 引用$/m, `${label} must not disable blockquotes`);
+    assert.match(normalizedInvisible, /^- 列表项$/m, `${label} must not disable lists`);
+  }
+
+  // A table renderer must preserve the parser context that Marked attaches at
+  // render time. Losing it makes one table throw and forces the entire lecture
+  // into the escaped plain-text fallback, exposing headings such as `##`.
+  const markdownPolicy = {
+    sanitize: (value) => value,
+    sanitizeSvg: (value) => value
+  };
+  const renderedLecture = new rendering.MarkdownEngine(markdownPolicy).render([
+    '## 核心概念',
+    '',
+    '### 判断方法',
+    '',
+    '| 设问类型 | 回应重心 |',
+    '| --- | --- |',
+    '| 综合分析 | 判断依据 |'
+  ].join('\n'));
+  assert.equal(renderedLecture.warnings.length, 0);
+  assert.match(renderedLecture.html, /<h2>核心概念<\/h2>/);
+  assert.match(renderedLecture.html, /<h3>判断方法<\/h3>/);
+  assert.match(renderedLecture.html, /<div class="markdown-table-scroll"><table>/);
+
+  // Leading whitespace is list-nesting depth, not spacing, so collapsing it
+  // flattens nested lists and dissolves indented code blocks.
+  assert.equal(rendering.normalizeMarkdownSource('- 外层\n  - 内层'), '- 外层\n  - 内层');
+  assert.match(rendering.normalizeMarkdownSource('```\n    缩进保留\n```'), /^ {4}缩进保留$/m);
+
+  // Chinese section numbering carries the structure of long-form model output,
+  // but Markdown renders it as plain prose, so a whole lecture reads unrendered.
+  const enumeratedLecture = rendering.normalizeMarkdownSource([
+    '一、核心概念',
+    '论证结构考查前提与结论的支持关系。',
+    '（一）识别信号',
+    '题干出现结论指示词。',
+    '【常见误区】',
+    '把结论错误当成论证有缺陷。'
+  ].join('\n'));
+  assert.match(enumeratedLecture, /^## 核心概念$/m);
+  assert.match(enumeratedLecture, /^### 识别信号$/m);
+  assert.match(enumeratedLecture, /^## 常见误区$/m);
+
+  // Everything below must stay untouched, or the rewrite turns ordinary prose
+  // and chat replies into tables of contents.
+  const authoredHeadings = rendering.normalizeMarkdownSource('## 已有标题\n一、这条是正文\n二、这条也是');
+  assert.match(authoredHeadings, /^一、这条是正文$/m);
+
+  const orderedList = rendering.normalizeMarkdownSource('1. 买菜\n2. 做饭\n3. 洗碗');
+  assert.match(orderedList, /^1\. 买菜$/m);
+  assert.doesNotMatch(orderedList, /^#{1,6} /m);
+
+  const singleMarker = rendering.normalizeMarkdownSource('开头说明\n一、唯一一条\n结尾说明');
+  assert.match(singleMarker, /^一、唯一一条$/m);
+
+  const numberedSentences = rendering.normalizeMarkdownSource(
+    '一、这是一句完整的话，它有逗号也有句号。\n二、这也是一句完整的话，同样带着句号。'
+  );
+  assert.match(numberedSentences, /^一、这是一句完整的话/m);
+
+  const fencedSample = rendering.normalizeMarkdownSource('```\n一、代码里的编号\n二、也不动\n```');
+  assert.match(fencedSample, /^一、代码里的编号$/m);
 
   const parser = new content.GeneratedContentParser();
   const embeddedLecture = parser.parseObject({
@@ -224,6 +334,60 @@ try {
   assert.equal(groupedPayload.questions.length, 2);
   assert.equal(groupedPayload.questions[0].materialGroupId, 'material-1');
   assert.deepEqual(groupedPayload.questions[0].material, groupedPayload.questions[1].material);
+
+  const dataAnalysisPayload = parser.parseObject({
+    lecture: { sections: [{ kind: 'concept', title: '增长率', markdown: '先读表，再定位年份与指标。' }] },
+    materialGroups: [{
+      id: 'data-material-1',
+      markdown: '某地区主要经济指标如下。',
+      table: {
+        caption: '主要经济指标',
+        unit: '亿元',
+        columns: [
+          { label: '年份', alignment: 'left', valueType: 'text' },
+          { label: '生产总值', alignment: 'right', valueType: 'number' },
+          { label: '同比增速', alignment: 'right', valueType: 'percent' }
+        ],
+        rows: [['2024', 1200, '6.2%'], ['2025', 1290, '7.5%']],
+        sourceNote: 'AI 生成练习数据'
+      },
+      visual: {
+        svg: '<svg><rect x="10" y="20" width="30" height="60" /><rect x="60" y="10" width="30" height="70" /></svg>',
+        alt: '2024 年与 2025 年生产总值对比柱状图',
+        viewBox: '0 0 100 100'
+      },
+      chart: {
+        type: 'combo',
+        title: '生产总值与同比增速',
+        unit: '亿元 / %',
+        categories: ['2024', '2025'],
+        series: [
+          { label: '生产总值', values: [1200, 1290], renderAs: 'bar' },
+          { label: '同比增速', values: [6.2, 7.5], renderAs: 'line' }
+        ],
+        sourceNote: 'AI 生成练习数据'
+      }
+    }],
+    questions: [1, 2].map((sequence) => ({
+      materialGroupId: 'data-material-1',
+      material: null,
+      prompt: `根据资料，第 ${sequence} 个问题的正确答案是哪项？`,
+      options: ['100', '120', '150', '180'].map((text) => ({ text })),
+      correctOptionId: 'A',
+      explanation: { knowledgePoint: '增长量计算' }
+    }))
+  }, 'aptitude.data_analysis.growth');
+  assert.deepEqual(
+    dataAnalysisPayload.questions[0].material.blocks.map((block) => block.type),
+    ['text', 'data_table', 'statistical_chart', 'svg_diagram']
+  );
+  assert.equal(dataAnalysisPayload.questions[0].material.blocks[1].rows[1].column_3, '7.5%');
+  assert.equal(dataAnalysisPayload.questions[0].material.blocks[2].series[1].renderAs, 'line');
+  assert.match(dataAnalysisPayload.questions[0].material.blocks[3].markup, /viewBox="0 0 100 100"/);
+  assert.equal(
+    content.resolveQuestionPresentation(dataAnalysisPayload.questions[0]),
+    content.QuestionPresentationCode.DataMaterialChoice
+  );
 
   console.log('Content schema verification passed.');
 } finally {

--- a/scripts/verify-generation-foundation.mjs
+++ b/scripts/verify-generation-foundation.mjs
@@ -24,9 +24,29 @@ try {
   ]);
   assert.match(
     corePolicy.practiceCoreSystem('base', 'aptitude.data_analysis.growth'),
-    /materialGroups/,
+    /materialGroups\.table/,
     'data analysis must receive its shared-material structural contract'
   );
+  const materialGroupSchema = ai.structuredObjectivePromptV2.responseSchema
+    .properties.materialGroups.items.properties;
+  assert.equal(materialGroupSchema.table.type, 'object');
+  assert.equal(materialGroupSchema.chart.type, 'object');
+  assert.equal(materialGroupSchema.visual.type, 'object');
+  const dataAnalysisSchema = corePolicy.practiceCoreResponseSchema(
+    ai.structuredObjectivePromptV2.responseSchema,
+    2,
+    'aptitude.data_analysis.growth'
+  );
+  const ordinarySchema = corePolicy.practiceCoreResponseSchema(
+    ai.structuredObjectivePromptV2.responseSchema,
+    2,
+    'aptitude.judgment.argument_structure'
+  );
+  assert.equal(dataAnalysisSchema.properties.materialGroups.items.properties.table.type, 'object');
+  assert.equal(dataAnalysisSchema.properties.materialGroups.items.properties.chart.type, 'object');
+  assert.equal(ordinarySchema.properties.materialGroups.items.properties.table, undefined);
+  assert.equal(ordinarySchema.properties.materialGroups.items.properties.chart, undefined);
+  assert.equal(ordinarySchema.properties.materialGroups.items.properties.visual, undefined);
   assert.match(
     corePolicy.practiceCoreSystem('base', 'aptitude.judgment.graphical.position'),
     /viewBox/,

--- a/scripts/verify-prompt-compiler.mjs
+++ b/scripts/verify-prompt-compiler.mjs
@@ -66,7 +66,7 @@ try {
   assert(compiled.system.includes('# 第6章 提交前质检'));
   assert(compiled.system.includes('本次生成 5 道题'));
   assert(!compiled.system.includes('{{QUESTION_COUNT}}'));
-  assert.equal(compiled.version, '2.4.2');
+  assert.equal(compiled.version, '2.6.0');
   assert(compiled.system.includes('最小真题参考包'));
   assert(compiled.system.includes('generationVariation'));
   assert(!compiled.responseSchema.properties.questions.items.required.includes('referenceQuestionId'));

--- a/scripts/verify-question-set-retirement.mjs
+++ b/scripts/verify-question-set-retirement.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createServer } from '../web/node_modules/vite/dist/node/index.js';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../web');
+const server = await createServer({
+  root,
+  configFile: false,
+  resolve: { alias: { '@': path.join(root, 'src') } },
+  server: { middlewareMode: true, hmr: false, ws: false },
+  appType: 'custom'
+});
+
+try {
+  const [content, retireModule, essayModule] = await Promise.all([
+    server.ssrLoadModule('/src/modules/content/public.ts'),
+    server.ssrLoadModule('/src/modules/content/application/RetireQuestionSet.ts'),
+    server.ssrLoadModule('/src/features/practice/EssayPracticeCenterFeature.ts')
+  ]);
+
+  await verifyObjectiveRetirement(content, retireModule);
+  await verifyEssayRetirement(content, essayModule);
+  console.log('Question-set retirement verification passed.');
+} finally {
+  await server.close();
+}
+
+async function verifyObjectiveRetirement(content, { RetireQuestionSet }) {
+  const calls = [];
+  const bundle = { questionSet: { id: 'QuestionSetId:ready', status: content.QuestionSetStatus.Ready } };
+  const repository = {
+    findQuestionSet: async () => bundle,
+    retireQuestionSet: async (id, context) => calls.push({ id, context })
+  };
+  const context = { transaction: 'test' };
+  const unitOfWork = {
+    run: async (work) => work(context),
+    runAutocommit: async (work) => work(context)
+  };
+  const useCase = new RetireQuestionSet(unitOfWork, repository);
+
+  assert.equal(await useCase.execute(bundle.questionSet.id), true);
+  assert.deepEqual(calls, [{ id: bundle.questionSet.id, context }]);
+
+  bundle.questionSet.status = content.QuestionSetStatus.Retired;
+  assert.equal(await useCase.execute(bundle.questionSet.id), false);
+  assert.equal(calls.length, 1, 'retiring an already retired set must be idempotent');
+}
+
+async function verifyEssayRetirement(content, { EssayPracticeCenterFeature }) {
+  const retired = [];
+  const cancelled = [];
+  const runtime = {
+    candidateRepository: {
+      findCurrentCycle: async () => ({ examCycle: { id: 'ExamCycleId:test' } })
+    },
+    getAgentRunViews: {
+      execute: async () => [{
+        id: 'AgentRunId:enrichment',
+        isActive: true,
+        questionSetId: 'EssayQuestionSetId:test',
+        targetResourceId: '',
+        actionParams: {}
+      }]
+    },
+    cancelAgentRun: {
+      execute: async (input) => cancelled.push(input)
+    },
+    learningAssetStore: {
+      retireBusinessKey: async (cycleId, kind, key) => retired.push({ cycleId, kind, key })
+    }
+  };
+  const feature = new EssayPracticeCenterFeature(runtime);
+  await feature.retireSet({
+    key: 'EssayQuestionSetId:test',
+    updatedAt: 1,
+    classification: content.LearningAssetPurpose.Practice,
+    context: {
+      questionSetId: 'EssayQuestionSetId:test',
+      date: '2026-08-12',
+      topic: '归纳概括',
+      type: 'short',
+      entryMode: 'self',
+      purpose: 'practice'
+    }
+  });
+
+  assert.deepEqual(retired.map((item) => item.kind), [
+    content.LearningAssetKind.EssayQuestion,
+    content.LearningAssetKind.EssayDraft
+  ]);
+  assert.equal(
+    retired.some((item) => item.kind === content.LearningAssetKind.EssayAttempt),
+    false,
+    'completed essay attempts and assessment evidence must remain available'
+  );
+  assert.equal(cancelled.length, 1, 'unfinished work for the retired set should be cancelled');
+}

--- a/scripts/verify-study-lecture-library.mjs
+++ b/scripts/verify-study-lecture-library.mjs
@@ -4,11 +4,13 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const [service, view, executor, prioritySnapshot] = await Promise.all([
+const [service, view, executor, prioritySnapshot, identity, learningCenter] = await Promise.all([
   read('web/src/services/StudyService.ts'),
   read('web/src/views/StudyView.vue'),
   read('web/src/composition-root/agent/BusinessAgentExecutors.ts'),
-  read('web/src/modules/tutoring/application/BuildLearnerPrioritySnapshot.ts')
+  read('web/src/modules/tutoring/application/BuildLearnerPrioritySnapshot.ts'),
+  read('web/src/domain/studyLecture.ts'),
+  read('web/src/views/LearningCenterView.vue')
 ]);
 
 assert.match(service, /async listLectures\(limit = 20\)/);
@@ -21,7 +23,11 @@ assert.match(view, /title="我的讲义"/);
 assert.match(view, /practiceModuleLabel\(lecture\.module\)/);
 assert.match(view, /studyService\.listLectures\(\)/);
 assert.match(view, /openLecture\(lecture\.id, lecture\.capabilityNodeId\)/);
-assert.match(view, /query: \{ assetId, \.\.\.\(capabilityNodeId/);
+// Opening a stored lecture must keep both linkages, or completing it stops
+// closing out the daily-plan item and stops crediting the capability.
+assert.match(view, /query: \{\s*assetId,/);
+assert.match(view, /dailyPlanItemId: dailyPlanItemId\.value/);
+assert.match(view, /capabilityNodeId: capabilityNode\b/);
 assert.match(view, /route\.query\.taskId/);
 assert.match(view, /studyService\.startDailyPlanLecture/);
 assert.match(view, /studyService\.markLectureStarted/);
@@ -31,9 +37,25 @@ assert.match(prioritySnapshot, /this\.progress\.listByCycle/);
 assert.match(prioritySnapshot, /learningStatus/);
 assert.match(service, /trackLearningProgress\.complete/);
 assert.match(executor, /kind: LearningAssetKind\.StudyLecture/);
-assert.match(executor, /businessKey: `study:\$\{moduleCode\}:\$\{topic\}`/);
 assert.match(executor, /moduleLabel: module/);
 assert.match(executor, /capabilityNodeId/);
+
+// A lecture belongs to its knowledge point, so revisiting one reopens what was
+// already written. Writer and reader must derive the same key from the shared
+// helper: if they drift apart the lookup silently misses and every visit pays
+// for a regeneration again.
+assert.match(identity, /export function studyLectureBusinessKey\(moduleCode: string, topic: string\)/);
+assert.match(identity, /return `study:\$\{normalizedModule\}:\$\{normalizedTopic\}`/);
+assert.match(executor, /businessKey: studyLectureBusinessKey\(moduleCode, topic\)/);
+assert.match(service, /studyLectureBusinessKey\(moduleCode, point\.name\)/);
+assert.match(service, /private async findReadyLecture/);
+assert.match(service, /findLatest\(\s*cycle\.examCycle\.id,\s*LearningAssetKind\.StudyLecture,/);
+assert.match(service, /if \(!options\.regenerate\)/);
+assert.match(service, /kind: 'ready'/);
+assert.match(service, /kind: 'generating'/);
+// Both entry points have to honour the reuse decision, not just one of them.
+assert.match(view, /presentLectureEntry/);
+assert.match(learningCenter, /entry\.kind === 'ready' \? \{ assetId: entry\.assetId \} : \{ taskId: entry\.task\.id \}/);
 
 console.log('Study lecture library verification passed.');
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "web-frontend",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-frontend",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@capacitor/core": "^8.4.1",
         "@earendil-works/pi-agent-core": "0.83.0",
         "@earendil-works/pi-ai": "0.83.0",
         "@mozilla/readability": "^0.6.0",
+        "chart.js": "^4.5.1",
         "dompurify": "^3.4.12",
         "katex": "^0.17.0",
         "lucide-vue-next": "^0.378.0",
@@ -579,6 +580,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmmirror.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@mistralai/mistralai": {
       "version": "2.2.6",
@@ -1547,6 +1554,18 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/commander": {
       "version": "8.3.0",

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "check:question-source-foundation": "node ../scripts/verify-question-source-foundation.mjs",
     "check:question-import-workflow": "node ../scripts/verify-question-import-workflow.mjs",
     "check:true-question-practice": "node ../scripts/verify-true-question-practice.mjs",
+    "check:question-set-retirement": "node ../scripts/verify-question-set-retirement.mjs",
     "check:true-question-reference-pack": "node ../scripts/verify-true-question-reference-pack.mjs",
     "check:study-lecture-library": "node ../scripts/verify-study-lecture-library.mjs",
     "check:essay-question-sets": "node ../scripts/verify-essay-question-set-classification.mjs",
@@ -39,7 +40,7 @@
     "check:ability-calibration": "node ../scripts/verify-ability-calibration.mjs",
     "check:interview-training": "node ../scripts/verify-interview-training.mjs",
     "typecheck": "vue-tsc",
-    "build": "npm run check:code-quality && npm run check:release-security && npm run check:architecture && npm run check:sqlite-migrations && npm run check:data-maintenance && npm run check:metadata && npm run check:content-metadata && npm run check:content-schema && npm run check:content-quality-benchmark && npm run check:prompt-compiler && npm run check:provider-gateway && npm run check:web-research && npm run check:document-input && npm run check:generation-workflow && npm run check:generation-diversity && npm run check:generation-foundation && npm run check:content-enrichment && npm run check:question-source-foundation && npm run check:question-import-workflow && npm run check:true-question-practice && npm run check:true-question-reference-pack && npm run check:study-lecture-library && npm run check:essay-question-sets && npm run check:proactive-tutor-loop && npm run check:learning-evidence && npm run check:learning-reliability && npm run check:ios-lifecycle-recovery && npm run check:agent-runtime && npm run check:agent-loop && npm run check:pi-agent-runtime && npm run check:chat-context && npm run check:mastery-policy && npm run check:ability-calibration && npm run check:interview-training && npm run typecheck && vite build",
+    "build": "npm run check:code-quality && npm run check:release-security && npm run check:architecture && npm run check:sqlite-migrations && npm run check:data-maintenance && npm run check:metadata && npm run check:content-metadata && npm run check:content-schema && npm run check:content-quality-benchmark && npm run check:prompt-compiler && npm run check:provider-gateway && npm run check:web-research && npm run check:document-input && npm run check:generation-workflow && npm run check:generation-diversity && npm run check:generation-foundation && npm run check:content-enrichment && npm run check:question-source-foundation && npm run check:question-import-workflow && npm run check:true-question-practice && npm run check:question-set-retirement && npm run check:true-question-reference-pack && npm run check:study-lecture-library && npm run check:essay-question-sets && npm run check:proactive-tutor-loop && npm run check:learning-evidence && npm run check:learning-reliability && npm run check:ios-lifecycle-recovery && npm run check:agent-runtime && npm run check:agent-loop && npm run check:pi-agent-runtime && npm run check:chat-context && npm run check:mastery-policy && npm run check:ability-calibration && npm run check:interview-training && npm run typecheck && vite build",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -47,6 +48,7 @@
     "@earendil-works/pi-agent-core": "0.83.0",
     "@earendil-works/pi-ai": "0.83.0",
     "@mozilla/readability": "^0.6.0",
+    "chart.js": "^4.5.1",
     "dompurify": "^3.4.12",
     "katex": "^0.17.0",
     "lucide-vue-next": "^0.378.0",
@@ -58,8 +60,8 @@
     "vue-router": "^4.3.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^6.0.8",
     "@types/node": "^22.10.0",
+    "@vitejs/plugin-vue": "^6.0.8",
     "typescript": "^5.2.2",
     "vite": "^8.2.1",
     "vue-tsc": "^2.0.6"

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -3,8 +3,10 @@
     <AppBackground :key="backgroundRenderKey" />
     <main :class="['main-content', { 'with-bottom-nav': showBottomNav }]">
       <router-view v-slot="{ Component }">
-        <ViewErrorBoundary :key="route.fullPath">
-          <component :is="Component" />
+        <ViewErrorBoundary>
+          <KeepAlive :include="CACHED_TAB_ROOTS">
+            <component :is="Component" />
+          </KeepAlive>
         </ViewErrorBoundary>
       </router-view>
     </main>
@@ -46,6 +48,22 @@ import AppBackground from '@/components/layout/AppBackground.vue';
 import PageGuideFab from '@/components/layout/PageGuideFab.vue';
 import TaskToast from '@/components/TaskToast.vue';
 import ViewErrorBoundary from '@/components/layout/ViewErrorBoundary.vue';
+
+/**
+ * Tab roots stay mounted so returning to one is instant, instead of replaying
+ * header, skeleton, spinner and content on every switch of the bottom nav.
+ * Second-level pages are absent on purpose and keep being rebuilt per visit.
+ *
+ * The practice centre is also absent for now: it reads its entry mode from the
+ * route query at setup time and owns a poll timer cleared on unmount, so it
+ * needs activation-aware handling of its own before it can be cached.
+ */
+const CACHED_TAB_ROOTS = [
+  'HomeView',
+  'LearningCenterView',
+  'TutorWrongBookView',
+  'ProfileView'
+];
 
 const route = useRoute();
 const showBottomNav = computed(() => route.meta.tabRoot === true);

--- a/web/src/capabilities/ai-runtime/fixtures/businessTutorPromptCatalog.ts
+++ b/web/src/capabilities/ai-runtime/fixtures/businessTutorPromptCatalog.ts
@@ -257,15 +257,15 @@ export const businessTutorPromptCatalog: readonly PromptBundle[] = [
     code: BusinessTutorPromptCode.StudyLecture,
     taskType: 'study_lecture',
     description: '生成围绕细分知识点的教材式精讲',
-    version: '1.2.0',
-    hash: 'sha256:3b8f4e8e444d26195e818ca006b72b730a2279b29e8b109b284150ea3afda614',
+    version: '1.3.0',
+    hash: 'sha256:67dd401a47ecbe0c1d6e398727e40b27d36fe1273946e8e27dd761ea11568a99',
     sections: [
       section(PromptSectionCode.Role, '私教身份与边界', 10, '你是公务员考试考点精讲老师。围绕一个细分知识点教学，不输出思考过程。'),
       section(PromptSectionCode.TeachingObjective, '教学目标', 20, '帮助考生建立概念边界、识别信号、稳定方法、陷阱意识和迁移能力，而不是只记一道题的答案。'),
       section(PromptSectionCode.InputContract, '输入规格', 30, '输入包含模块、知识点、可选个性化要求和 generationVariation。缺少学生证据时使用通用讲解，不假装了解其错因。generationVariation 只决定本轮组织视角并提示近期内容轮廓，必须保持知识点边界，不得机械复述 recentOutlinesToAvoid。'),
-      section(PromptSectionCode.OutputContract, '输出合同', 40, '输出 GFM Markdown。根据知识点与考生状态自主组织章节，可使用核心概念、边界辨析、方法、例子、陷阱、迁移练习和复盘提问等内容，不要求每次凑齐固定栏目。'),
+      section(PromptSectionCode.OutputContract, '输出合同', 40, '只输出 GFM Markdown。每个章节必须以 ## 标题开头，章节内更细的层级依次使用 ### 和 ####。禁止用「一、」「（一）」「1、」或【】充当标题，这些不会被渲染成标题，只会显示为普通段落。章节的选取和数量由知识点决定，可使用核心概念、边界辨析、方法、例子、陷阱、迁移练习和复盘提问等内容，不要求每次凑齐固定栏目。'),
       section(PromptSectionCode.QualityRules, '讲义质量', 50, '重要内容必须覆盖概念边界和可执行方法；选用的方法要给出识别条件和操作步骤，选用的例子必须服务于知识点。其他内容、篇幅和组织方式由 AI 自主决定；禁止“认真审题、多刷题”等空泛建议。'),
-      section(PromptSectionCode.SelfCheck, '提交前质检', 60, '检查内容围绕单一细分知识点、结构完整、可用于后续配套练习，然后输出最终 Markdown。')
+      section(PromptSectionCode.SelfCheck, '提交前质检', 60, '检查内容围绕单一细分知识点、结构完整、可用于后续配套练习，并逐条确认每个章节标题都写成了 ## 或更深的 Markdown 标题，然后输出最终 Markdown。')
     ]
   })
 ];

--- a/web/src/capabilities/ai-runtime/fixtures/structuredObjectivePromptV2.ts
+++ b/web/src/capabilities/ai-runtime/fixtures/structuredObjectivePromptV2.ts
@@ -42,7 +42,108 @@ const responseSchema: JsonObject = {
         required: ['id', 'markdown'],
         properties: {
           id: { type: 'string', minLength: 1 },
-          markdown: { type: 'string', minLength: 1 }
+          markdown: { type: 'string', minLength: 1 },
+          table: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['columns', 'rows'],
+            properties: {
+              caption: { type: 'string', minLength: 1 },
+              unit: { type: 'string', minLength: 1 },
+              columns: {
+                type: 'array',
+                minItems: 2,
+                maxItems: 12,
+                items: {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['label'],
+                  properties: {
+                    label: { type: 'string', minLength: 1 },
+                    alignment: { type: 'string', enum: ['left', 'center', 'right'] },
+                    valueType: { type: 'string', enum: ['text', 'number', 'percent'] }
+                  }
+                }
+              },
+              rows: {
+                type: 'array',
+                minItems: 1,
+                maxItems: 80,
+                items: {
+                  type: 'array',
+                  minItems: 2,
+                  maxItems: 12,
+                  items: { type: ['string', 'number', 'null'] }
+                }
+              },
+              sourceNote: { type: 'string', minLength: 1 }
+            }
+          },
+          chart: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['type', 'categories', 'series'],
+            properties: {
+              type: {
+                type: 'string',
+                enum: ['bar', 'horizontal_bar', 'line', 'pie', 'doughnut', 'stacked_bar', 'combo', 'scatter']
+              },
+              title: { type: 'string', minLength: 1 },
+              unit: { type: 'string', minLength: 1 },
+              categories: {
+                type: 'array',
+                minItems: 0,
+                maxItems: 40,
+                items: { type: 'string', minLength: 1 }
+              },
+              series: {
+                type: 'array',
+                minItems: 1,
+                maxItems: 8,
+                items: {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['label'],
+                  properties: {
+                    label: { type: 'string', minLength: 1 },
+                    values: {
+                      type: 'array',
+                      minItems: 1,
+                      maxItems: 40,
+                      items: { type: ['number', 'null'] }
+                    },
+                    points: {
+                      type: 'array',
+                      minItems: 1,
+                      maxItems: 80,
+                      items: {
+                        type: 'object',
+                        additionalProperties: false,
+                        required: ['x', 'y'],
+                        properties: {
+                          x: { type: 'number' },
+                          y: { type: 'number' },
+                          label: { type: 'string', minLength: 1 }
+                        }
+                      }
+                    },
+                    renderAs: { type: 'string', enum: ['bar', 'line'] }
+                  }
+                }
+              },
+              sourceNote: { type: 'string', minLength: 1 }
+            }
+          },
+          visual: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['svg', 'alt'],
+            properties: {
+              svg: { type: 'string', minLength: 1 },
+              alt: { type: 'string', minLength: 1 },
+              viewBox: { type: 'string', minLength: 1 }
+            }
+          }
         }
       }
     },
@@ -143,12 +244,12 @@ const responseSchema: JsonObject = {
 
 export const structuredObjectivePromptV2: PromptBundle = {
   definitionId: 'prompt-definition:content-generate-structured-objective',
-  versionId: 'prompt-version:content-generate-structured-objective:v15' as PromptVersionId,
+  versionId: 'prompt-version:content-generate-structured-objective:v17' as PromptVersionId,
   promptCode: 'content.generate.aptitude.structured_objective',
   taskType: 'lecture_with_questions',
   description: '围绕指定能力节点生成结构化讲义与单选训练题',
-  version: '2.4.2',
-  contentHash: 'sha256:39d5f77ee1bb641d439e55e1b6c369c24723d507424442e273067c38194030ca',
+  version: '2.6.0',
+  contentHash: 'sha256:a1b13553e8674e1663b2ca4b71fe188bee01c714a5b0ff1ebf5196d0f6790425',
   createdAt: 1784016000000 as InstantMs,
   requiredVariables: ['QUESTION_COUNT', 'ASSESSMENT_ROLE', 'DIFFICULTY_MIN', 'DIFFICULTY_MAX'],
   compatibleSchemaVersions: ['content.v1', 'question.single_choice.v2'],
@@ -174,7 +275,7 @@ export const structuredObjectivePromptV2: PromptBundle = {
         '讲义应根据目标能力、学生证据和本次教学目的，自主选择最有帮助的章节、例子、方法和提醒，不为凑固定数量重复内容。',
         '每道题都必须评估当前目标能力节点。允许通过材料、难度和干扰项做前置能力或相邻迁移变化，但不得改变本题的目标能力归属。',
         '题目必须使用单选合同，但题干和选项可使用 GFM Markdown、表格或 visual 字段承载安全的 SVG。',
-        '资料分析优先把完整数据表保存到 materialGroups；数量关系解析必须给出关键算式；图形推理必须提供单个有 viewBox 的 SVG 画布并保持图形比例。',
+        '资料分析优先把完整数据表保存到 materialGroups.table，把柱状图、折线图、饼图、堆叠图、组合图或散点图保存到 materialGroups.chart；只有无法用统计数据表达的特殊示意图才使用 visual。',
         '长材料多问必须使用 materialGroups；普通单题不得为了排版而伪造公共材料组。'
       ].join('\n')
     },
@@ -208,6 +309,9 @@ export const structuredObjectivePromptV2: PromptBundle = {
         '论证、文段、实验、调查、案例和数据等作答依据必须完整放入 material，prompt 只写设问。prompt 如果指代“上述、以上、前述、题干、材料中、文中、该论证”等内容，对应 material 不得为 null。',
         '只有 prompt 自身已经包含全部事实、条件和关系、无需读取任何前文时，独立题的 material 才能为 null；禁止输出缺少前置材料的空设问。',
         '只有一个完整公共材料对应至少两道小题时才使用 materialGroups：公共材料只保存一次，每道小题用相同 materialGroupId 引用，且 material 必须为 null。',
+        'materialGroups.markdown 保存资料说明和必要文字；规则数据优先写入 table，统计图写入 chart，特殊示意图才写入 visual。不要在 markdown 中重复结构化块已承载的完整数据。',
+        'table.columns 按展示顺序描述列，table.rows 使用同顺序的单元格数组；行内单元格数量必须与列数一致。visual 必须是含 viewBox 的完整 SVG，并保持坐标和比例。',
+        'chart.categories 是横轴分类，chart.series.values 必须与分类数量一致；组合图用 renderAs 指定 bar 或 line，散点图使用 points 的 x/y 数值。图表颜色和移动端布局由应用统一决定，不要生成颜色或坐标像素。',
         '多段文字仍是一个完整材料，不得按段落拆成多个 materialGroups；小题问法只写入 prompt，不得混进公共材料。',
         'options 按 A、B、C……顺序输出 2 至 8 项；标准行测通常使用 A、B、C、D，option.id 可以省略并由应用确定性注入；correctOptionId 必须引用实际存在的选项。',
         '数学公式仅在有助于理解或作答时使用 KaTeX 兼容 LaTeX：行内公式使用 $...$，独立公式使用 $$...$$，百分号写成 \\%。由于公式位于 JSON 字符串内，LaTeX 反斜杠必须按 JSON 规则转义，例如源内容 \\frac 在 JSON 中写成 \\\\frac；不得用代码块或反引号包裹公式。',

--- a/web/src/capabilities/content-rendering/markdown/MarkdownEngine.ts
+++ b/web/src/capabilities/content-rendering/markdown/MarkdownEngine.ts
@@ -60,10 +60,14 @@ export class MarkdownEngine {
 
 function createMarkedRenderer(): Marked {
   const renderer = new Renderer();
-  const renderTable = renderer.table.bind(renderer);
-  renderer.table = (token: Tokens.Table): string => (
-    `<div class="markdown-table-scroll">${renderTable(token)}</div>`
-  );
+  const renderTable = renderer.table;
+  renderer.table = function table(token: Tokens.Table): string {
+    // Marked injects its parser onto the renderer used for the active parse.
+    // Calling a function bound while the renderer is being constructed loses
+    // that runtime parser and makes every Markdown table throw. Keep `this`
+    // from the active render and only decorate the resulting table markup.
+    return `<div class="markdown-table-scroll">${renderTable.call(this, token)}</div>`;
+  };
   renderer.link = function link(token: Tokens.Link): string {
     const label = this.parser.parseInline(token.tokens);
     const resolved = resolveLink(token.href);
@@ -107,11 +111,13 @@ function restoreSafeImageSources(html: string): string {
  * fenced code blocks remain untouched.
  */
 export function normalizeMarkdownSource(source: string): string {
-  const document = normalizeMathSyntax(
-    unwrapMarkdownDocumentFence(
-      decodeMarkdownTransportEscapes(unwrapSerializedMarkdown(source).replace(/\r\n?/g, '\n'))
+  const document = promoteEnumeratedSectionHeadings(normalizeMathSyntax(
+    stripInvisibleCharacters(
+      unwrapMarkdownDocumentFence(
+        decodeMarkdownTransportEscapes(unwrapSerializedMarkdown(source).replace(/\r\n?/g, '\n'))
+      )
     )
-  );
+  ));
   const lines = document.split('\n');
   const normalized: string[] = [];
   let inFence = false;
@@ -144,6 +150,106 @@ export function normalizeMarkdownSource(source: string): string {
     }
   }
   return normalizeTolerantPipeTables(normalized).join('\n');
+}
+
+const ZERO_WIDTH_CHARACTERS = /[\u200B\u200C\u200D\u2060\uFEFF]/g;
+const NON_ASCII_SPACE_CLASS = '\\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000';
+const NON_ASCII_SPACES = new RegExp(`[${NON_ASCII_SPACE_CLASS}]`, 'g');
+const HAS_NON_ASCII_SPACE = new RegExp(`[${NON_ASCII_SPACE_CLASS}]`);
+const LEADING_WHITESPACE = new RegExp(`^[ \\t${NON_ASCII_SPACE_CLASS}]*`);
+
+/**
+ * Removes invisible characters that silently switch Markdown off.
+ *
+ * CommonMark accepts only ASCII space and tab as leading whitespace, so a
+ * single non-breaking or ideographic space in front of a line stops `##`, `>`,
+ * `-` and every other block construct from being recognised — the document
+ * collapses into one paragraph and renders exactly as if it had never been
+ * parsed. Chinese model output carries these constantly and the damage is
+ * invisible on inspection, which makes it worth normalizing before parsing
+ * rather than chasing per-document.
+ *
+ * A leading run that contained one of them is dropped rather than converted:
+ * full-width indentation is decorative here, and turning it into four ASCII
+ * spaces would swap one silent failure for another by forming a code block.
+ * Fenced code keeps its bytes, where invisible characters may be the subject.
+ */
+function stripInvisibleCharacters(source: string): string {
+  let inFence = false;
+  return source.split('\n').map((line) => {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      return line;
+    }
+    if (inFence) return line;
+    const cleaned = line.replace(ZERO_WIDTH_CHARACTERS, '');
+    const leading = LEADING_WHITESPACE.exec(cleaned)?.[0] ?? '';
+    const body = cleaned.slice(leading.length).replace(NON_ASCII_SPACES, ' ');
+    const indent = HAS_NON_ASCII_SPACE.test(leading) ? '' : leading;
+    return `${indent}${body}`;
+  }).join('\n');
+}
+
+/** `一、`, `（一）`, `【…】` — section markers Markdown renders as ordinary prose. */
+const IDEOGRAPHIC_SECTION = /^\s*([一二三四五六七八九十百]+)\s*[、.．]\s*(\S.*)$/;
+const PARENTHESIZED_SECTION = /^\s*[（(]\s*([一二三四五六七八九十百]+)\s*[）)]\s*(\S.*)$/;
+const BRACKETED_SECTION = /^\s*【\s*([^】]{1,24})\s*】\s*$/;
+const SECTION_TITLE_MAX = 30;
+const MIN_PROMOTED_SECTIONS = 2;
+
+/**
+ * Rewrites Chinese section numbering into real Markdown headings.
+ *
+ * Models writing long-form Chinese habitually structure documents with `一、`
+ * and `（一）` instead of `##`. Markdown has no meaning for either, so the whole
+ * document renders as one flat run of paragraphs and reads as though it were
+ * never rendered at all.
+ *
+ * The rewrite is deliberately narrow. It only runs on documents that carry no
+ * Markdown heading of their own — an author who used `#` already expressed the
+ * structure, and their numbered lines are content. It only touches markers
+ * Markdown itself ignores, so `1.` and `1)` keep being ordered lists rather
+ * than turning a shopping list into a table of contents. And it needs at least
+ * two of them, so one numbered sentence in a paragraph is left alone.
+ */
+function promoteEnumeratedSectionHeadings(source: string): string {
+  if (/^\s{0,3}#{1,6}\s/m.test(source)) return source;
+  const lines = source.split('\n');
+  const promoted: Array<{ readonly index: number; readonly text: string }> = [];
+  let inFence = false;
+  lines.forEach((line, index) => {
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      return;
+    }
+    if (inFence) return;
+    const heading = sectionHeading(line);
+    if (heading) promoted.push({ index, text: heading });
+  });
+  if (promoted.length < MIN_PROMOTED_SECTIONS) return source;
+  promoted.forEach(({ index, text }) => {
+    lines[index] = text;
+  });
+  return lines.join('\n');
+}
+
+function sectionHeading(line: string): string | undefined {
+  const bracketed = BRACKETED_SECTION.exec(line);
+  if (bracketed) return `## ${bracketed[1]!.trim()}`;
+  const ideographic = IDEOGRAPHIC_SECTION.exec(line);
+  if (ideographic && isSectionTitle(ideographic[2]!)) return `## ${ideographic[2]!.trim()}`;
+  const parenthesized = PARENTHESIZED_SECTION.exec(line);
+  if (parenthesized && isSectionTitle(parenthesized[2]!)) return `### ${parenthesized[2]!.trim()}`;
+  return undefined;
+}
+
+/** A heading is a short label; a numbered sentence ends like a sentence. */
+function isSectionTitle(text: string): boolean {
+  const title = text.trim();
+  return title.length > 0
+    && title.length <= SECTION_TITLE_MAX
+    && !/[。！？；;]$/.test(title)
+    && !/[。！？]/.test(title);
 }
 
 function mathExtension() {
@@ -309,10 +415,12 @@ function stripDecorativeEmoji(value: string): string {
   } catch {
     // Older iOS JavaScript runtimes may not recognize this Unicode property.
   }
-  return normalized
-    .replace(/[\uFE0F\u200D\u20E3]/g, '')
-    .replace(/[ \t]{2,}/g, ' ')
-    .trimEnd();
+  const withoutJoiners = normalized.replace(/[\uFE0F\u200D\u20E3]/g, '');
+  // Runs left behind by a removed emoji are collapsed, but the leading run is
+  // structure rather than spacing: Markdown reads it as list nesting depth, so
+  // squeezing it flattens nested lists and dissolves indented code blocks.
+  const indent = /^[ \t]*/.exec(withoutJoiners)?.[0] ?? '';
+  return `${indent}${withoutJoiners.slice(indent.length).replace(/[ \t]{2,}/g, ' ')}`.trimEnd();
 }
 
 function escapeAttribute(value: string): string {

--- a/web/src/capabilities/design-system/components/SwipeActionRow.types.ts
+++ b/web/src/capabilities/design-system/components/SwipeActionRow.types.ts
@@ -1,0 +1,10 @@
+import type { Component } from 'vue';
+
+export interface SwipeActionRowAction {
+  readonly id: string;
+  readonly label: string;
+  readonly ariaLabel?: string;
+  readonly icon?: Component;
+  readonly tone?: 'default' | 'danger';
+  readonly disabled?: boolean;
+}

--- a/web/src/capabilities/design-system/components/SwipeActionRow.vue
+++ b/web/src/capabilities/design-system/components/SwipeActionRow.vue
@@ -1,0 +1,221 @@
+<template>
+  <div
+    ref="root"
+    class="swipe-action-row"
+    :class="{ dragging, open: isOpen, disabled }"
+    @pointerdown="handlePointerDown"
+    @pointermove="handlePointerMove"
+    @pointerup="finishPointer"
+    @pointercancel="cancelPointer"
+    @keydown.esc="close"
+  >
+    <div class="swipe-actions" :style="{ width: `${actionAreaWidth}px` }">
+      <button
+        v-for="action in actions"
+        :key="action.id"
+        type="button"
+        :class="['swipe-action', action.tone || 'default']"
+        :aria-label="action.ariaLabel || action.label"
+        :disabled="disabled || action.disabled"
+        @focus="open"
+        @click.stop="runAction(action.id)"
+      >
+        <component :is="action.icon" v-if="action.icon" />
+        <span>{{ action.label }}</span>
+      </button>
+    </div>
+    <div
+      class="swipe-foreground"
+      :style="{ transform: `translate3d(${offset}px, 0, 0)` }"
+      @click.capture="handleForegroundClick"
+    >
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import type { SwipeActionRowAction } from './SwipeActionRow.types';
+
+const ACTION_WIDTH = 76;
+const OPEN_THRESHOLD_RATIO = .36;
+const DIRECTION_LOCK_PX = 5;
+const OPEN_EVENT = 'design-system:swipe-action-open';
+
+const props = withDefaults(defineProps<{
+  actions: readonly SwipeActionRowAction[];
+  disabled?: boolean;
+}>(), {
+  disabled: false
+});
+
+const emit = defineEmits<{
+  action: [actionId: string];
+}>();
+
+const root = ref<HTMLElement | null>(null);
+const offset = ref(0);
+const dragging = ref(false);
+const actionAreaWidth = computed(() => Math.max(0, props.actions.length * ACTION_WIDTH));
+const isOpen = computed(() => offset.value < 0);
+
+let pointerId: number | null = null;
+let startX = 0;
+let startY = 0;
+let startOffset = 0;
+let horizontalGesture = false;
+let moved = false;
+
+onMounted(() => window.addEventListener(OPEN_EVENT, handleAnotherRowOpened as EventListener));
+onBeforeUnmount(() => window.removeEventListener(OPEN_EVENT, handleAnotherRowOpened as EventListener));
+
+function handlePointerDown(event: PointerEvent) {
+  if (props.disabled || !props.actions.length || event.button !== 0) return;
+  pointerId = event.pointerId;
+  startX = event.clientX;
+  startY = event.clientY;
+  startOffset = offset.value;
+  horizontalGesture = false;
+  moved = false;
+}
+
+function handlePointerMove(event: PointerEvent) {
+  if (pointerId !== event.pointerId || props.disabled) return;
+  const deltaX = event.clientX - startX;
+  const deltaY = event.clientY - startY;
+  if (!horizontalGesture) {
+    if (Math.abs(deltaX) < DIRECTION_LOCK_PX && Math.abs(deltaY) < DIRECTION_LOCK_PX) return;
+    if (Math.abs(deltaY) >= Math.abs(deltaX)) {
+      pointerId = null;
+      return;
+    }
+    horizontalGesture = true;
+    dragging.value = true;
+    root.value?.setPointerCapture(event.pointerId);
+  }
+  event.preventDefault();
+  moved = moved || Math.abs(deltaX) > DIRECTION_LOCK_PX;
+  offset.value = clamp(startOffset + deltaX, -actionAreaWidth.value, 0);
+}
+
+function finishPointer(event: PointerEvent) {
+  if (pointerId !== event.pointerId) return;
+  if (horizontalGesture) {
+    const shouldOpen = Math.abs(offset.value) >= actionAreaWidth.value * OPEN_THRESHOLD_RATIO;
+    shouldOpen ? open() : close();
+  }
+  releasePointer(event.pointerId);
+}
+
+function cancelPointer(event: PointerEvent) {
+  if (pointerId !== event.pointerId) return;
+  close();
+  releasePointer(event.pointerId);
+}
+
+function releasePointer(id: number) {
+  if (root.value?.hasPointerCapture(id)) root.value.releasePointerCapture(id);
+  pointerId = null;
+  horizontalGesture = false;
+  dragging.value = false;
+  window.setTimeout(() => { moved = false; }, 0);
+}
+
+function handleForegroundClick(event: MouseEvent) {
+  if (!moved && !isOpen.value) return;
+  event.preventDefault();
+  event.stopPropagation();
+  close();
+}
+
+function open() {
+  if (props.disabled || !actionAreaWidth.value) return;
+  offset.value = -actionAreaWidth.value;
+  window.dispatchEvent(new CustomEvent(OPEN_EVENT, { detail: root.value }));
+}
+
+function close() {
+  offset.value = 0;
+}
+
+function runAction(actionId: string) {
+  close();
+  emit('action', actionId);
+}
+
+function handleAnotherRowOpened(event: CustomEvent<HTMLElement | null>) {
+  if (event.detail !== root.value) close();
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+</script>
+
+<style scoped>
+.swipe-action-row {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  touch-action: pan-y;
+}
+
+.swipe-actions {
+  position: absolute;
+  inset: 0 0 0 auto;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 76px;
+}
+
+.swipe-action {
+  min-width: 0;
+  border: 0;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  color: var(--text-color);
+  background: var(--surface-muted);
+  font: inherit;
+  font-size: var(--type-size-caption);
+  font-weight: var(--type-weight-semibold);
+}
+
+.swipe-action.danger {
+  color: #fff;
+  background: var(--red-color);
+}
+
+.swipe-action:disabled {
+  opacity: .45;
+}
+
+.swipe-action svg {
+  width: 18px;
+  height: 18px;
+}
+
+.swipe-foreground {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+  background: inherit;
+  transition: transform .2s cubic-bezier(.22, .8, .25, 1);
+  will-change: transform;
+}
+
+.dragging .swipe-foreground {
+  transition: none;
+}
+
+.disabled {
+  touch-action: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .swipe-foreground { transition-duration: .01ms; }
+}
+</style>

--- a/web/src/capabilities/design-system/public.ts
+++ b/web/src/capabilities/design-system/public.ts
@@ -11,3 +11,5 @@ export { default as PullToRefresh } from './components/PullToRefresh.vue';
 export { default as SurfaceCard } from './components/SurfaceCard.vue';
 export { default as SegmentedControl } from './components/SegmentedControl.vue';
 export { default as StickyActionBar } from './components/StickyActionBar.vue';
+export { default as SwipeActionRow } from './components/SwipeActionRow.vue';
+export type { SwipeActionRowAction } from './components/SwipeActionRow.types';

--- a/web/src/components/MarkdownContent.vue
+++ b/web/src/components/MarkdownContent.vue
@@ -63,21 +63,59 @@ const html = computed(() => {
 .markdown-content :deep(p:last-child) {
   margin-bottom: 0;
 }
+/* Headings carry the document structure, so every level has to read as a
+   level: visibly larger than body copy and visibly different from the level
+   above. The deepest levels step down by weight and colour instead of by
+   size, because a heading smaller than its own paragraphs inverts the
+   hierarchy and makes rendered Markdown look unrendered. */
 .markdown-content :deep(h1),
 .markdown-content :deep(h2),
 .markdown-content :deep(h3),
-.markdown-content :deep(h4) {
-  margin: 12px 0 7px;
+.markdown-content :deep(h4),
+.markdown-content :deep(h5),
+.markdown-content :deep(h6) {
   color: var(--text-color);
+  font-weight: var(--type-weight-semibold);
+  line-height: var(--type-line-title);
+}
+.markdown-content :deep(h1) {
+  margin: 20px 0 10px;
+  font-size: var(--type-size-page-title);
+  font-weight: var(--type-weight-bold);
+}
+.markdown-content :deep(h2) {
+  margin: 18px 0 9px;
+  font-size: var(--type-size-section-title);
+}
+.markdown-content :deep(h3) {
+  margin: 15px 0 7px;
+  font-size: var(--type-size-body-large);
+}
+.markdown-content :deep(h4) {
+  margin: 13px 0 6px;
   font-size: var(--type-size-body);
-  line-height: 1.45;
 }
 .markdown-content :deep(h5),
 .markdown-content :deep(h6) {
-  margin: 10px 0 6px;
+  margin: 11px 0 5px;
+  color: var(--text-secondary-color);
+  font-size: var(--type-size-body);
+}
+.markdown-content :deep(h6) {
+  font-weight: var(--type-weight-medium);
+}
+.markdown-content :deep(h1:first-child),
+.markdown-content :deep(h2:first-child),
+.markdown-content :deep(h3:first-child),
+.markdown-content :deep(h4:first-child),
+.markdown-content :deep(h5:first-child),
+.markdown-content :deep(h6:first-child) {
+  margin-top: 0;
+}
+/* Emphasis has to survive surfaces that dim their body copy to secondary. */
+.markdown-content :deep(strong) {
   color: var(--text-color);
-  font-size: var(--type-size-secondary);
-  line-height: 1.45;
+  font-weight: var(--type-weight-semibold);
 }
 .markdown-content :deep(hr) {
   height: 1px;
@@ -285,6 +323,25 @@ const html = computed(() => {
   margin-top: 6px;
   margin-bottom: 6px;
 }
+/* Dense surfaces drop the whole ladder one step rather than flattening it. */
+.markdown-content-compact :deep(h1) {
+  margin: 14px 0 7px;
+  font-size: var(--type-size-section-title);
+}
+.markdown-content-compact :deep(h2) {
+  margin: 13px 0 6px;
+  font-size: var(--type-size-body-large);
+}
+.markdown-content-compact :deep(h3) {
+  margin: 12px 0 6px;
+  font-size: var(--type-size-body);
+}
+.markdown-content-compact :deep(h4),
+.markdown-content-compact :deep(h5),
+.markdown-content-compact :deep(h6) {
+  margin: 10px 0 5px;
+  font-size: var(--type-size-secondary);
+}
 .markdown-content-chat {
   overflow-wrap: anywhere;
   line-height: 1.58;
@@ -296,10 +353,12 @@ const html = computed(() => {
 .markdown-content-chat :deep(blockquote),
 .markdown-content-chat :deep(pre),
 .markdown-content-chat :deep(.markdown-table-scroll) { margin: 8px 0 0; }
-.markdown-content-chat :deep(h1),
-.markdown-content-chat :deep(h2),
+.markdown-content-chat :deep(h1) { margin: 12px 0 6px; font-size: var(--type-size-section-title); }
+.markdown-content-chat :deep(h2) { margin: 11px 0 6px; font-size: var(--type-size-body-large); }
 .markdown-content-chat :deep(h3),
-.markdown-content-chat :deep(h4) { margin: 10px 0 6px; font-size: var(--type-size-body-large); line-height: 1.35; }
+.markdown-content-chat :deep(h4),
+.markdown-content-chat :deep(h5),
+.markdown-content-chat :deep(h6) { margin: 10px 0 5px; font-size: var(--type-size-body); }
 .markdown-content-chat :deep(pre) {
   border: 1px solid rgba(var(--color-ink-rgb), .07);
   border-radius: 9px;

--- a/web/src/components/content/ContentDocumentRenderer.vue
+++ b/web/src/components/content/ContentDocumentRenderer.vue
@@ -3,11 +3,20 @@
     <template v-for="block in document.blocks" :key="block.id">
       <TextContent v-if="block.type === 'text'" :content="block.source" :variant="textVariant" />
 
-      <figure v-else-if="block.type === 'data_table'" class="content-table">
+      <figure
+        v-else-if="block.type === 'data_table'"
+        class="content-table"
+        :class="{ 'content-table-dense': block.columns.length >= 5, 'content-table-very-dense': block.columns.length >= 7 }"
+      >
         <figcaption v-if="block.caption || block.unit">{{ block.caption }}<small v-if="block.unit">{{ block.unit }}</small></figcaption>
         <div class="content-table-scroll"><table><thead><tr><th v-for="column in block.columns" :key="column.key" :style="{ textAlign: column.alignment }">{{ column.label }}</th></tr></thead><tbody><tr v-for="(row, index) in block.rows" :key="index"><td v-for="column in block.columns" :key="column.key" :style="{ textAlign: column.alignment }">{{ row[column.key] ?? '-' }}</td></tr></tbody></table></div>
         <p v-if="block.sourceNote" class="content-source-note">{{ block.sourceNote }}</p>
       </figure>
+
+      <StatisticalChart
+        v-else-if="block.type === 'statistical_chart'"
+        :block="block"
+      />
 
       <figure v-else-if="block.type === 'svg_diagram'" class="content-diagram"><div class="content-svg" role="img" :aria-label="block.alt" v-html="sanitizeSvg(block.markup)"></div><figcaption>{{ block.alt }}</figcaption></figure>
 
@@ -36,6 +45,7 @@ import { HtmlPolicy, ImageSourceKind, resolveImageSource } from '@/capabilities/
 import type { ContentDocument } from '@/modules/content/public';
 import TextContent from '@/components/content/TextContent.vue';
 import MathFormula from '@/components/content/MathFormula.vue';
+import StatisticalChart from '@/components/content/StatisticalChart.vue';
 
 defineOptions({ name: 'ContentDocumentRenderer' });
 withDefaults(defineProps<{
@@ -61,7 +71,7 @@ function remoteImage(value: string): string | undefined {
 </script>
 
 <style scoped>
-.content-document-renderer { display:flex; flex-direction:column; gap:10px; min-width:0; }.content-table,.content-diagram,.content-image { margin:0; }.content-table figcaption,.content-diagram figcaption,.content-image figcaption { margin-bottom:6px; color:var(--text-secondary-color); font-size:var(--type-size-caption); }.content-table figcaption small { margin-left:6px; font-size:inherit; }.content-table-scroll { overflow-x:auto; border-radius:8px; background:rgba(var(--color-ink-rgb),.035); -webkit-overflow-scrolling:touch; }.content-table table { width:100%; min-width:400px; border-collapse:collapse; font-size:var(--type-size-caption); }.content-table th,.content-table td { padding:8px 9px; border-bottom:1px solid rgba(var(--color-ink-rgb),.07); white-space:nowrap; }.content-table th { color:var(--text-color); background:rgba(var(--color-ink-rgb),.045); font-weight:var(--type-weight-semibold); }.content-source-note { margin:5px 0 0; color:var(--text-secondary-color); font-size:var(--type-size-micro); }.content-svg { width:100%; max-height:260px; overflow:hidden; display:grid; place-items:center; border-radius:8px; background:rgba(var(--color-ink-rgb),.025); }.content-svg :deep(svg) { display:block; width:100%; height:auto; max-height:260px; }.content-diagram figcaption { margin-top:5px; text-align:center; }.content-image img { display:block; width:100%; max-height:340px; object-fit:contain; border-radius:8px; }.content-image-unavailable { color:var(--text-secondary-color); font-size:var(--type-size-caption); }.content-callout { padding:10px 11px; border-left:3px solid var(--primary-color); border-radius:0 8px 8px 0; background:rgba(var(--color-brand-rgb),.06); }.content-callout>strong { display:block; margin-bottom:5px; font-size:var(--type-size-secondary); }.content-callout-trap,.content-callout-wrong_cause { border-left-color:var(--orange-color); background:rgba(255,149,0,.08); }.content-callout-conclusion { border-left-color:var(--green-color); background:rgba(52,199,89,.08); }
+.content-document-renderer { display:flex; flex-direction:column; gap:10px; min-width:0; }.content-table,.content-diagram,.content-image { max-width:100%; margin:0; }.content-table figcaption,.content-diagram figcaption,.content-image figcaption { margin-bottom:6px; color:var(--text-secondary-color); font-size:var(--type-size-caption); }.content-table figcaption small { margin-left:6px; font-size:inherit; }.content-table-scroll { width:100%; max-width:100%; min-width:0; overflow-x:hidden; border-radius:8px; background:rgba(var(--color-ink-rgb),.035); }.content-table table { width:100%; max-width:100%; table-layout:fixed; border-collapse:collapse; font-size:var(--type-size-caption); font-variant-numeric:tabular-nums; }.content-table th,.content-table td { padding:8px 7px; border-right:1px solid rgba(var(--color-ink-rgb),.05); border-bottom:1px solid rgba(var(--color-ink-rgb),.07); white-space:normal; overflow-wrap:anywhere; word-break:break-word; }.content-table th { color:var(--text-color); background:rgba(var(--color-ink-rgb),.045); font-weight:var(--type-weight-semibold); }.content-table-dense th,.content-table-dense td { padding:7px 4px; font-size:var(--type-size-micro); }.content-table-very-dense th,.content-table-very-dense td { padding:6px 2px; line-height:1.35; }.content-source-note { margin:5px 0 0; color:var(--text-secondary-color); font-size:var(--type-size-micro); }.content-svg { width:100%; max-height:260px; overflow:hidden; display:grid; place-items:center; border-radius:8px; background:rgba(var(--color-ink-rgb),.025); }.content-svg :deep(svg) { display:block; width:100%; height:auto; max-height:260px; }.content-diagram figcaption { margin-top:5px; text-align:center; }.content-image img { display:block; width:100%; max-height:340px; object-fit:contain; border-radius:8px; }.content-image-unavailable { color:var(--text-secondary-color); font-size:var(--type-size-caption); }.content-callout { padding:10px 11px; border-left:3px solid var(--primary-color); border-radius:0 8px 8px 0; background:rgba(var(--color-brand-rgb),.06); }.content-callout>strong { display:block; margin-bottom:5px; font-size:var(--type-size-secondary); }.content-callout-trap,.content-callout-wrong_cause { border-left-color:var(--orange-color); background:rgba(255,149,0,.08); }.content-callout-conclusion { border-left-color:var(--green-color); background:rgba(52,199,89,.08); }
 .content-document-renderer-lecture { gap:0; }
 .content-document-renderer-lecture>.content-callout { position:relative; margin-top:15px; padding:16px 0 2px; border:0; border-top:1px solid rgba(var(--color-ink-rgb),.075); border-radius:0; background:transparent; }
 .content-document-renderer-lecture>.content-callout>strong { display:flex; align-items:center; gap:8px; margin-bottom:9px; color:var(--text-color); font-size:var(--type-size-body); line-height:1.4; }

--- a/web/src/components/content/LectureContent.vue
+++ b/web/src/components/content/LectureContent.vue
@@ -5,11 +5,7 @@
       :document="document"
       presentation="lecture"
     />
-    <MarkdownContent
-      v-else-if="markdown"
-      class="lecture-markdown"
-      :content="markdown"
-    />
+    <MarkdownContent v-else-if="markdown" :content="markdown" />
   </article>
 </template>
 
@@ -39,32 +35,5 @@ withDefaults(defineProps<{
   padding: 16px;
   border-color: transparent;
   background: rgba(255, 255, 255, .72);
-}
-
-.lecture-markdown {
-  color: var(--text-secondary-color);
-}
-
-.lecture-markdown :deep(h1),
-.lecture-markdown :deep(h2) {
-  margin-top: 18px;
-  color: var(--text-color);
-  font-size: var(--type-size-section-title);
-}
-
-.lecture-markdown :deep(h1:first-child),
-.lecture-markdown :deep(h2:first-child) {
-  margin-top: 0;
-}
-
-.lecture-markdown :deep(h3),
-.lecture-markdown :deep(h4) {
-  margin-top: 14px;
-  color: var(--text-color);
-  font-size: var(--type-size-body);
-}
-
-.lecture-markdown :deep(strong) {
-  color: var(--text-color);
 }
 </style>

--- a/web/src/components/content/StatisticalChart.vue
+++ b/web/src/components/content/StatisticalChart.vue
@@ -1,0 +1,196 @@
+<template>
+  <figure class="statistical-chart">
+    <figcaption v-if="block.title || block.unit" class="statistical-chart-caption">
+      <span>{{ block.title }}</span>
+      <small v-if="block.unit">{{ block.unit }}</small>
+    </figcaption>
+    <div class="statistical-chart-canvas" :class="`statistical-chart-${block.chartType}`">
+      <canvas ref="canvasRef" role="img" :aria-label="chartLabel">
+        {{ chartLabel }}
+      </canvas>
+    </div>
+    <p v-if="block.sourceNote" class="statistical-chart-source">{{ block.sourceNote }}</p>
+  </figure>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import type {
+  Chart as ChartInstance,
+  ChartConfiguration,
+  ChartDataset,
+  ChartType,
+  Point
+} from 'chart.js';
+import type { StatisticalChartBlock, StatisticalChartSeries } from '@/modules/content/public';
+
+const props = defineProps<{ readonly block: StatisticalChartBlock }>();
+const canvasRef = ref<HTMLCanvasElement>();
+let chart: ChartInstance | undefined;
+let renderSequence = 0;
+
+const chartLabel = computed(() => {
+  const title = props.block.title || '统计图';
+  return props.block.unit ? `${title}，单位：${props.block.unit}` : title;
+});
+
+onMounted(() => { void renderChart(); });
+watch(() => props.block, () => { void renderChart(); }, { deep: true });
+onBeforeUnmount(() => {
+  renderSequence += 1;
+  chart?.destroy();
+  chart = undefined;
+});
+
+async function renderChart(): Promise<void> {
+  const sequence = ++renderSequence;
+  await nextTick();
+  const canvas = canvasRef.value;
+  if (!canvas) return;
+  const module = await import('chart.js/auto');
+  if (sequence !== renderSequence || !canvasRef.value) return;
+  chart?.destroy();
+  chart = new module.default(canvas, chartConfiguration(props.block, canvas));
+}
+
+function chartConfiguration(block: StatisticalChartBlock, canvas: HTMLCanvasElement): ChartConfiguration {
+  const palette = chartPalette(canvas);
+  const circular = block.chartType === 'pie' || block.chartType === 'doughnut';
+  const datasets = block.series.map((series, index) => chartDataset(block, series, index, palette));
+  const type = baseChartType(block.chartType);
+  return {
+    type,
+    data: {
+      labels: [...block.categories],
+      datasets: datasets as ChartConfiguration['data']['datasets']
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      resizeDelay: 120,
+      animation: prefersReducedMotion() ? false : { duration: 260 },
+      indexAxis: block.chartType === 'horizontal_bar' ? 'y' : 'x',
+      interaction: { mode: 'nearest', intersect: false },
+      plugins: {
+        legend: {
+          display: circular || block.series.length > 1,
+          position: 'bottom',
+          labels: { boxWidth: 10, boxHeight: 10, usePointStyle: true, padding: 12 }
+        },
+        tooltip: { enabled: true }
+      },
+      scales: circular ? undefined : {
+        x: {
+          stacked: block.chartType === 'stacked_bar',
+          grid: { display: false },
+          ticks: { autoSkip: true, maxTicksLimit: 7, maxRotation: 0, minRotation: 0 }
+        },
+        y: {
+          stacked: block.chartType === 'stacked_bar',
+          beginAtZero: block.chartType !== 'scatter',
+          title: { display: Boolean(block.unit), text: block.unit },
+          grid: { color: palette.grid }
+        }
+      }
+    }
+  };
+}
+
+function chartDataset(
+  block: StatisticalChartBlock,
+  series: StatisticalChartSeries,
+  index: number,
+  palette: ChartPalette
+): ChartDataset<ChartType, Array<number | Point | null>> {
+  const circular = block.chartType === 'pie' || block.chartType === 'doughnut';
+  const type = datasetChartType(block.chartType, series);
+  const color = palette.series[index % palette.series.length];
+  const data = block.chartType === 'scatter'
+    ? (series.points ?? []).map((point) => ({ x: point.x, y: point.y }))
+    : [...(series.values ?? [])];
+  return {
+    type,
+    label: series.label,
+    data,
+    borderColor: circular ? palette.surface : color.solid,
+    backgroundColor: circular
+      ? block.categories.map((_, categoryIndex) => palette.series[categoryIndex % palette.series.length].fill)
+      : color.fill,
+    borderWidth: circular ? 2 : type === 'line' ? 2 : 1,
+    pointRadius: type === 'line' || type === 'scatter' ? 3 : 0,
+    pointHoverRadius: type === 'line' || type === 'scatter' ? 5 : 0,
+    tension: type === 'line' ? 0.22 : 0,
+    fill: false
+  };
+}
+
+function baseChartType(chartType: StatisticalChartBlock['chartType']): ChartType {
+  if (chartType === 'pie' || chartType === 'doughnut' || chartType === 'line' || chartType === 'scatter') {
+    return chartType;
+  }
+  return 'bar';
+}
+
+function datasetChartType(
+  chartType: StatisticalChartBlock['chartType'],
+  series: StatisticalChartSeries
+): ChartType {
+  if (chartType === 'combo') return series.renderAs ?? 'bar';
+  return baseChartType(chartType);
+}
+
+interface PaletteColor {
+  readonly solid: string;
+  readonly fill: string;
+}
+
+interface ChartPalette {
+  readonly series: readonly PaletteColor[];
+  readonly grid: string;
+  readonly surface: string;
+}
+
+function chartPalette(canvas: HTMLCanvasElement): ChartPalette {
+  const style = getComputedStyle(canvas);
+  const colors = [
+    cssColor(style, '--primary-color', '#287a68'),
+    cssColor(style, '--blue-color', '#2878c8'),
+    cssColor(style, '--green-color', '#34a36f'),
+    cssColor(style, '--orange-color', '#d88724'),
+    cssColor(style, '--red-color', '#cf4c4c'),
+    '#7a6fb3'
+  ];
+  return {
+    series: colors.map((color) => ({ solid: color, fill: withAlpha(color, 0.58) })),
+    grid: withAlpha(cssColor(style, '--text-secondary-color', '#667085'), 0.15),
+    surface: cssColor(style, '--surface-color', '#ffffff')
+  };
+}
+
+function cssColor(style: CSSStyleDeclaration, name: string, fallback: string): string {
+  return style.getPropertyValue(name).trim() || fallback;
+}
+
+function withAlpha(color: string, alpha: number): string {
+  const hex = color.match(/^#([\da-f]{6})$/i)?.[1];
+  if (hex) {
+    const channels = [0, 2, 4].map((offset) => Number.parseInt(hex.slice(offset, offset + 2), 16));
+    return `rgba(${channels.join(', ')}, ${alpha})`;
+  }
+  const rgb = color.match(/^rgba?\(([^)]+)\)$/i)?.[1]?.split(',').slice(0, 3).map((item) => item.trim());
+  return rgb?.length === 3 ? `rgba(${rgb.join(', ')}, ${alpha})` : color;
+}
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+</script>
+
+<style scoped>
+.statistical-chart { width:100%; max-width:100%; margin:0; min-width:0; }
+.statistical-chart-caption { display:flex; align-items:baseline; justify-content:space-between; gap:8px; margin-bottom:7px; color:var(--text-color); font-size:var(--type-size-caption); font-weight:var(--type-weight-semibold); }
+.statistical-chart-caption small { flex:0 0 auto; color:var(--text-secondary-color); font-size:var(--type-size-micro); font-weight:var(--type-weight-regular); }
+.statistical-chart-canvas { position:relative; width:100%; height:clamp(220px, 58vw, 300px); min-width:0; padding:8px 4px 2px; border-radius:8px; background:rgba(var(--color-ink-rgb),.025); overflow:hidden; }
+.statistical-chart-pie,.statistical-chart-doughnut { height:clamp(240px, 66vw, 320px); }
+.statistical-chart-source { margin:5px 0 0; color:var(--text-secondary-color); font-size:var(--type-size-micro); }
+</style>

--- a/web/src/components/layout/ViewErrorBoundary.vue
+++ b/web/src/components/layout/ViewErrorBoundary.vue
@@ -8,8 +8,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onErrorCaptured, ref } from 'vue';
+import { computed, onErrorCaptured, ref, watch } from 'vue';
+import { useRoute } from 'vue-router';
 
+const route = useRoute();
 const error = ref<unknown>();
 const message = computed(() => error.value instanceof Error ? error.value.message : '请稍后重试，或返回首页重新进入。');
 
@@ -17,6 +19,16 @@ onErrorCaptured((cause) => {
   console.error('[view error boundary]', cause);
   error.value = cause;
   return false;
+});
+
+/**
+ * The boundary used to be re-created per route through a `:key`, which also
+ * discarded every cached tab root on each navigation. Clearing the failure here
+ * keeps the same reset without destroying the view cache. A live failure still
+ * unmounts the slot, so the broken view is rebuilt from scratch on retry.
+ */
+watch(() => route.fullPath, () => {
+  error.value = undefined;
 });
 
 function retry() {

--- a/web/src/components/layout/useCachedViewRefresh.ts
+++ b/web/src/components/layout/useCachedViewRefresh.ts
@@ -1,0 +1,25 @@
+import { onActivated } from 'vue';
+
+/**
+ * Reloads a cached tab root when the user comes back to it.
+ *
+ * Tab roots live inside `<KeepAlive>`, so revisiting one never remounts it and
+ * `onMounted` runs exactly once. This hook owns the revisit instead: the
+ * already-rendered content stays on screen while the reload runs in the
+ * background, which is the entire point of caching them — replaying
+ * skeleton to spinner to content on every switch is the flicker being removed.
+ *
+ * The first activation is skipped because mounting has already loaded the view,
+ * and the hook is inert outside `<KeepAlive>`, so a view dropped from the cache
+ * whitelist keeps working without any change here.
+ */
+export function useCachedViewRefresh(refresh: () => void | Promise<void>): void {
+  let awaitingFirstActivation = true;
+  onActivated(() => {
+    if (awaitingFirstActivation) {
+      awaitingFirstActivation = false;
+      return;
+    }
+    void refresh();
+  });
+}

--- a/web/src/components/question/QuestionContentTemplate.vue
+++ b/web/src/components/question/QuestionContentTemplate.vue
@@ -2,7 +2,7 @@
   <article :class="['question-content-template', `question-template-${definition.code}`, `question-layout-${layout}`]">
     <template v-for="region in orderedRegions" :key="region">
       <section v-if="region === QuestionRegionCode.Material && question.material" class="question-region question-region-material">
-        <ContentDocumentRenderer :document="question.material" text-variant="compact" />
+        <ContentDocumentRenderer :document="question.material" :text-variant="materialTextVariant" />
       </section>
 
       <section v-else-if="region === QuestionRegionCode.Prompt" class="question-region question-region-prompt">
@@ -46,6 +46,7 @@ import QuestionOptionList from '@/components/question/QuestionOptionList.vue';
 import {
   QuestionRegionCode,
   QuestionRegionLayoutCode,
+  QuestionPresentationCode,
   questionPresentationDefinition,
   questionRegionOrder,
   resolveQuestionPresentation,
@@ -77,6 +78,9 @@ const props = withDefaults(defineProps<{
 
 const definition = computed(() => questionPresentationDefinition(
   props.presentation || resolveQuestionPresentation(props.question)
+));
+const materialTextVariant = computed(() => (
+  definition.value.code === QuestionPresentationCode.DataMaterialChoice ? 'data' : 'compact'
 ));
 const orderedRegions = computed(() => questionRegionOrder(props.layout)
   .filter((region) => definition.value.regions.includes(region)));

--- a/web/src/composition-root/agent/BusinessAgentExecutors.ts
+++ b/web/src/composition-root/agent/BusinessAgentExecutors.ts
@@ -3,6 +3,7 @@ import { buildEssayRepairPrompt, validateEssayQuestion } from '@/ai/QuestionVali
 import { BusinessTutorPromptCode, parseStructuredJson } from '@/capabilities/ai-runtime/public';
 import { normalizeMarkdownSource } from '@/capabilities/content-rendering/public';
 import { practiceModuleLabel } from '@/domain/labels';
+import { studyLectureBusinessKey } from '@/domain/studyLecture';
 import { abortableDelay, mapWithAbortableConcurrency } from '@/kernel/public';
 import type { DigestTab } from '@/domain/digest';
 import { aiChatRepository } from '@/services/AIChatRepository';
@@ -660,7 +661,7 @@ export const studyExecutor: BusinessAgentExecutor = async (task, context) => {
   await context.update(82, '生成精讲内容');
   const saved = await context.saveLearningAsset({
     kind: LearningAssetKind.StudyLecture,
-    businessKey: `study:${moduleCode}:${topic}`,
+    businessKey: studyLectureBusinessKey(moduleCode, topic),
     title: `${module} · ${topic}`,
     payload: {
       module: moduleCode,

--- a/web/src/composition-root/database/TutorDatabaseRuntime.ts
+++ b/web/src/composition-root/database/TutorDatabaseRuntime.ts
@@ -49,6 +49,7 @@ import type {
   QuestionImportDraftRepository,
   QuestionReferencePackRepository,
   QuestionSourceRepository,
+  RetireQuestionSet,
   RunStructuredObjectiveGenerationWorkflow,
   ScanQuestionImportDraft
 } from '@/modules/content/public';
@@ -168,6 +169,7 @@ export interface TutorDatabaseRuntime {
   readonly createGenerationWorkflow: CreateGenerationWorkflow;
   readonly runStructuredObjectiveGenerationWorkflow: RunStructuredObjectiveGenerationWorkflow;
   readonly applyQuestionSetEnrichment: ApplyQuestionSetEnrichment;
+  readonly retireQuestionSet: RetireQuestionSet;
   readonly ensureQuestionSetEnrichment: EnsureQuestionSetEnrichment;
   readonly getGenerationStatus: GetGenerationStatus;
   readonly createLearningThread: CreateLearningThread;

--- a/web/src/composition-root/database/createNativeTutorDatabase.ts
+++ b/web/src/composition-root/database/createNativeTutorDatabase.ts
@@ -18,10 +18,7 @@ import {
   UpdateScoreTargets
 } from '@/modules/candidate/public';
 import { SqliteCurriculumRepository } from '@/modules/curriculum/adapters/SqliteCurriculumRepository';
-import {
-  createBundledNationalCurriculum,
-  EnsureCurriculumBundle
-} from '@/modules/curriculum/public';
+import { createBundledNationalCurriculum, EnsureCurriculumBundle } from '@/modules/curriculum/public';
 import { SqliteOutboxRepository } from '@/modules/task/adapters/SqliteOutboxRepository';
 import { SqliteCommandReceiptRepository } from '@/modules/task/adapters/SqliteCommandReceiptRepository';
 import { UuidV7IdGenerator } from '@/capabilities/platform/public';
@@ -57,6 +54,7 @@ import {
   ImportQuestionSource,
   LearningAssetStore,
   PublishQuestionImportDraft,
+  RetireQuestionSet,
   RunStructuredObjectiveGenerationWorkflow,
   ScanQuestionImportDraft
 } from '@/modules/content/public';
@@ -251,6 +249,7 @@ export function createNativeTutorDatabase(clock: Clock): NativeTutorDatabaseRunt
     new UuidV7IdGenerator(clock)
   );
   const applyQuestionSetEnrichment = new ApplyQuestionSetEnrichment(unitOfWork, contentRepository);
+  const retireQuestionSet = new RetireQuestionSet(unitOfWork, contentRepository);
   const getGenerationStatus = new GetGenerationStatus(generationRepository, contentRepository);
   const createLearningThread = new CreateLearningThread(
     unitOfWork,
@@ -537,6 +536,7 @@ export function createNativeTutorDatabase(clock: Clock): NativeTutorDatabaseRunt
     createGenerationWorkflow,
     runStructuredObjectiveGenerationWorkflow,
     applyQuestionSetEnrichment,
+    retireQuestionSet,
     ensureQuestionSetEnrichment,
     getGenerationStatus,
     createLearningThread,

--- a/web/src/composition-root/database/createWebTutorDatabase.ts
+++ b/web/src/composition-root/database/createWebTutorDatabase.ts
@@ -14,10 +14,7 @@ import {
   UpdateScoreTargets
 } from '@/modules/candidate/public';
 import { IndexedDbCurriculumRepository } from '@/modules/curriculum/adapters/IndexedDbCurriculumRepository';
-import {
-  createBundledNationalCurriculum,
-  EnsureCurriculumBundle
-} from '@/modules/curriculum/public';
+import { createBundledNationalCurriculum, EnsureCurriculumBundle } from '@/modules/curriculum/public';
 import { IndexedDbOutboxRepository } from '@/modules/task/adapters/IndexedDbOutboxRepository';
 import { IndexedDbCommandReceiptRepository } from '@/modules/task/adapters/IndexedDbCommandReceiptRepository';
 import { UuidV7IdGenerator } from '@/capabilities/platform/public';
@@ -54,6 +51,7 @@ import {
   ImportQuestionSource,
   LearningAssetStore,
   PublishQuestionImportDraft,
+  RetireQuestionSet,
   RunStructuredObjectiveGenerationWorkflow,
   ScanQuestionImportDraft
 } from '@/modules/content/public';
@@ -252,6 +250,7 @@ export function createWebTutorDatabase(clock: Clock): WebTutorDatabaseRuntime {
     new UuidV7IdGenerator(clock)
   );
   const applyQuestionSetEnrichment = new ApplyQuestionSetEnrichment(unitOfWork, contentRepository);
+  const retireQuestionSet = new RetireQuestionSet(unitOfWork, contentRepository);
   const getGenerationStatus = new GetGenerationStatus(generationRepository, contentRepository);
   const createLearningThread = new CreateLearningThread(
     unitOfWork,
@@ -538,6 +537,7 @@ export function createWebTutorDatabase(clock: Clock): WebTutorDatabaseRuntime {
     createGenerationWorkflow,
     runStructuredObjectiveGenerationWorkflow,
     applyQuestionSetEnrichment,
+    retireQuestionSet,
     ensureQuestionSetEnrichment,
     getGenerationStatus,
     createLearningThread,

--- a/web/src/domain/studyLecture.ts
+++ b/web/src/domain/studyLecture.ts
@@ -1,0 +1,20 @@
+export const STUDY_LECTURE_DEFAULT_MODULE = '公考';
+
+/**
+ * Identity of a lecture in the learning-asset store.
+ *
+ * One knowledge point owns one lecture, so this key is what lets an already
+ * generated lecture be reused instead of regenerated. It is built from the
+ * module *code* rather than its display label, because labels are presentation
+ * and may be reworded without invalidating stored content.
+ *
+ * The generator and every reader must derive the key the same way; keeping the
+ * format in one place is what stops the two sides from drifting apart into a
+ * silent cache miss that quietly regenerates on every visit.
+ */
+export function studyLectureBusinessKey(moduleCode: string, topic: string): string {
+  const normalizedModule = moduleCode.trim() || STUDY_LECTURE_DEFAULT_MODULE;
+  const normalizedTopic = topic.trim();
+  if (!normalizedTopic) throw new TypeError('Study lecture identity requires a topic');
+  return `study:${normalizedModule}:${normalizedTopic}`;
+}

--- a/web/src/features/practice/EssayPracticeCenterFeature.ts
+++ b/web/src/features/practice/EssayPracticeCenterFeature.ts
@@ -10,6 +10,7 @@ import {
   normalizeEssayQuestionSetPurpose,
   type EssayQuestionSetPurpose
 } from '@/domain/essayQuestionSet';
+import { cancelQuestionSetRuns } from './cancelQuestionSetRuns';
 
 export type EssayPracticeMode = 'tutor' | 'self' | 'true';
 
@@ -86,5 +87,14 @@ export class EssayPracticeCenterFeature {
         question: questionFromAsset(asset)
       }))
       .sort((left, right) => right.updatedAt - left.updatedAt || right.key.localeCompare(left.key));
+  }
+
+  async retireSet(set: EssayPracticeSet): Promise<void> {
+    const cycle = await this.runtime.candidateRepository.findCurrentCycle();
+    if (!cycle) throw new Error('当前备考档案不可用。');
+    await cancelQuestionSetRuns(this.runtime, set.context.questionSetId || set.key);
+    for (const kind of [LearningAssetKind.EssayQuestion, LearningAssetKind.EssayDraft] as const) {
+      await this.runtime.learningAssetStore.retireBusinessKey(cycle.examCycle.id, kind, set.key);
+    }
   }
 }

--- a/web/src/features/practice/EssayPracticeCenterPanel.vue
+++ b/web/src/features/practice/EssayPracticeCenterPanel.vue
@@ -88,7 +88,7 @@
       <div class="essay-history">
         <button v-for="item in allStates" :key="item.key" type="button" @click="openSet(item)">
           <span>{{ item.question?.title || item.context.topic }}</span>
-            <em>{{ item.classification === 'legacy_unknown' ? '历史未分类' : modeLabelFor(item.context.entryMode) }} · {{ item.context.date }}</em>
+          <em>{{ item.classification === 'legacy_unknown' ? '历史未分类' : modeLabelFor(item.context.entryMode) }} · {{ item.context.date }}</em>
         </button>
         <AppStateView v-if="!allStates.length" compact title="暂无历史题组" description="完成一次申论生成后会显示在这里。" />
       </div>
@@ -193,7 +193,6 @@ const customTopic = ref('归纳概括');
 const customCount = ref(1);
 const allStates = ref<readonly EssayPracticeSet[]>([]);
 const essayTopics = ['归纳概括', '综合分析', '提出对策', '贯彻执行', '申发论述'];
-
 const modes = [
   { value: 'tutor' as const, label: '私教学习', icon: SparklesIcon },
   { value: 'self' as const, label: '自主刷题', icon: SlidersHorizontalIcon },

--- a/web/src/features/practice/PracticeCenterFeature.ts
+++ b/web/src/features/practice/PracticeCenterFeature.ts
@@ -9,6 +9,7 @@ import {
   type QuestionSetLibraryQuery
 } from '@/modules/content/public';
 import { TutorDailyPracticeFeature } from './TutorDailyPracticeFeature';
+import { cancelQuestionSetRuns } from './cancelQuestionSetRuns';
 
 /** Read model used by the practice center; generation commands remain explicit page actions. */
 export class PracticeCenterFeature {
@@ -103,6 +104,18 @@ export class PracticeCenterFeature {
           limit: query?.limit ?? 40
         })
       : [];
+  }
+
+  async retireQuestionSet(questionSetId: string): Promise<void> {
+    const bundle = await this.runtime.contentRepository.findQuestionSet(
+      questionSetId as Parameters<TutorDatabaseRuntime['contentRepository']['findQuestionSet']>[0]
+    );
+    const cycle = await this.runtime.candidateRepository.findCurrentCycle();
+    if (!bundle || !cycle || bundle.questionSet.examCycleId !== cycle.examCycle.id) {
+      throw new Error('题组不存在或不属于当前备考档案。');
+    }
+    await cancelQuestionSetRuns(this.runtime, questionSetId);
+    await this.runtime.retireQuestionSet.execute(bundle.questionSet.id);
   }
 
   async resolveLearningThread(questionSetId: string): Promise<string> {

--- a/web/src/features/practice/PracticeQuestionSetList.vue
+++ b/web/src/features/practice/PracticeQuestionSetList.vue
@@ -53,7 +53,9 @@ const props = defineProps<{
   onLoadMore: () => Promise<void> | void;
 }>();
 
-defineEmits<{ open: [set: QuestionSetLibraryEntry] }>();
+defineEmits<{
+  open: [set: QuestionSetLibraryEntry];
+}>();
 
 const viewport = ref<HTMLElement | null>(null);
 watch(() => [props.mode, props.sets[0]?.id], () => viewport.value?.scrollTo({ top: 0 }));

--- a/web/src/features/practice/PracticeSessionFeature.ts
+++ b/web/src/features/practice/PracticeSessionFeature.ts
@@ -3,6 +3,7 @@ import {
   findQuestionSetEnrichmentNeeds,
   hasQuestionSetEnrichmentNeeds,
   LearningAssetKind,
+  QuestionSetStatus,
   type CommittedQuestionSetBundle,
   type QuestionSetSourceSummary
 } from '@/modules/content/public';
@@ -40,7 +41,9 @@ export class PracticeSessionFeature {
       )
       : undefined;
     const bundle = manifest?.bundle ?? singleBundle;
-    if (!bundle) throw new Error('题组不存在或已不可用。');
+    if (!bundle || bundle.questionSet.status !== QuestionSetStatus.Ready) {
+      throw new Error('题组不存在或已不可用。');
+    }
 
     const [cycle, source] = await Promise.all([
       this.runtime.candidateRepository.findCurrentCycle(),

--- a/web/src/features/practice/cancelQuestionSetRuns.ts
+++ b/web/src/features/practice/cancelQuestionSetRuns.ts
@@ -1,0 +1,25 @@
+import type { TutorDatabaseRuntime } from '@/composition-root/public';
+
+/** Stops unfinished work for a question set before the set leaves the practice library. */
+export async function cancelQuestionSetRuns(
+  runtime: TutorDatabaseRuntime,
+  questionSetId: string
+): Promise<void> {
+  try {
+    const runs = await runtime.getAgentRunViews.execute({ limit: 100 });
+    const matching = runs.filter((run) => (
+      run.isActive
+      && (
+        run.questionSetId === questionSetId
+        || run.targetResourceId === questionSetId
+        || run.actionParams.questionSetId === questionSetId
+      )
+    ));
+    await Promise.allSettled(matching.map((run) => runtime.cancelAgentRun.execute({
+      agentRunId: run.id,
+      reason: 'question_set_retired'
+    })));
+  } catch {
+    // Retirement remains authoritative. Enrichment and practice entry both reject retired sets.
+  }
+}

--- a/web/src/features/wrongbook/TutorWrongBookView.vue
+++ b/web/src/features/wrongbook/TutorWrongBookView.vue
@@ -171,12 +171,16 @@ import BottomSheet from '@/components/layout/BottomSheet.vue';
 import CenterDialog from '@/components/layout/CenterDialog.vue';
 import QuestionContentTemplate from '@/components/question/QuestionContentTemplate.vue';
 import PageHeader from '@/components/layout/PageHeader.vue';
+import { useCachedViewRefresh } from '@/components/layout/useCachedViewRefresh';
 import ErrorDiagnosisInsight from '@/components/learning/ErrorDiagnosisInsight.vue';
 import { initializeTutorRuntime } from '@/composition-root/public';
 import { practiceModuleLabel } from '@/domain/labels';
 import { errorCauseLabel, type WrongBookDiagnosis, type WrongBookEntry } from '@/modules/evidence/public';
 import { QuestionRegionLayoutCode, type ContentDocument } from '@/modules/content/public';
 import { peekWrongBookEntries, WrongBookFeature } from './WrongBookFeature';
+
+// Named so App.vue can hold this tab root in its <KeepAlive> whitelist.
+defineOptions({ name: 'TutorWrongBookView' });
 
 const router = useRouter();
 const initialEntries = peekWrongBookEntries();
@@ -217,6 +221,9 @@ const flashcard = computed(() => filtered.value[flashcardIndex.value]);
 const showReviewAction = computed(() => mode.value === 'review' && loaded.value && !error.value && filtered.value.length > 0);
 
 onMounted(() => { void load(); });
+// Reloading keeps the listed entries on screen: `loaded` stays true, so the
+// refresh placeholder never comes back once the first page has arrived.
+useCachedViewRefresh(load);
 watch(filtered, () => { if (flashcardIndex.value >= filtered.value.length) flashcardIndex.value = Math.max(0, filtered.value.length - 1); });
 watch(flashcardIndex, () => { revealed.value = false; });
 watch(mode, (next) => {

--- a/web/src/modules/content/adapters/ApplyQuestionSetEnrichmentSql.ts
+++ b/web/src/modules/content/adapters/ApplyQuestionSetEnrichmentSql.ts
@@ -6,7 +6,7 @@ export async function applyQuestionSetEnrichmentSql(
   patch: QuestionSetEnrichmentPatch
 ): Promise<boolean> {
   const versions = await transaction.query<{ content_version: number }>(
-    'SELECT content_version FROM question_sets WHERE id = ? LIMIT 1',
+    `SELECT content_version FROM question_sets WHERE id = ? AND status = 'ready' LIMIT 1`,
     [patch.questionSetId]
   );
   if (versions[0]?.content_version !== patch.expectedContentVersion) return false;
@@ -52,7 +52,7 @@ export async function applyQuestionSetEnrichmentSql(
   const updatedQuestionSet = await transaction.run(
     `UPDATE question_sets
      SET content_hash = ?, content_version = content_version + 1
-     WHERE id = ? AND content_version = ?`,
+     WHERE id = ? AND content_version = ? AND status = 'ready'`,
     [patch.nextContentHash, patch.questionSetId, patch.expectedContentVersion]
   );
   if (updatedQuestionSet.changes !== 1) throw new Error('Question set enrichment version conflict');

--- a/web/src/modules/content/adapters/IndexedDbContentRepository.ts
+++ b/web/src/modules/content/adapters/IndexedDbContentRepository.ts
@@ -152,13 +152,27 @@ export class IndexedDbContentRepository implements ContentRepository {
 
   async listQuestionSets(examCycleId: ExamCycleId, limit: number): Promise<readonly CommittedQuestionSetBundle[]> {
     assertQuestionSetQueryLimit(limit);
-    return (await this.listAllQuestionSets(examCycleId)).slice(0, limit);
+    const stored = await this.database.getAll<StoredQuestionSetBundle>(TutorIndexedDbStore.ContentQuestionSetBundles);
+    return stored
+      .filter((item) => (
+        item.examCycleId === examCycleId
+        && item.bundle.questionSet.status === QuestionSetStatus.Ready
+      ))
+      .sort((left, right) => right.createdAt - left.createdAt)
+      .slice(0, limit)
+      .map((item) => normalizedBundle(item.bundle));
   }
 
   async listAllQuestionSets(examCycleId: ExamCycleId): Promise<readonly CommittedQuestionSetBundle[]> {
     const stored = await this.database.getAll<StoredQuestionSetBundle>(TutorIndexedDbStore.ContentQuestionSetBundles);
     return stored
-      .filter((item) => item.examCycleId === examCycleId && item.bundle.questionSet.status === QuestionSetStatus.Ready)
+      .filter((item) => (
+        item.examCycleId === examCycleId
+        && (
+          item.bundle.questionSet.status === QuestionSetStatus.Ready
+          || item.bundle.questionSet.status === QuestionSetStatus.Retired
+        )
+      ))
       .sort((left, right) => right.createdAt - left.createdAt)
       .map((item) => normalizedBundle(item.bundle));
   }
@@ -192,6 +206,27 @@ export class IndexedDbContentRepository implements ContentRepository {
     });
   }
 
+  async retireQuestionSet(questionSetId: QuestionSetId, context: TransactionContext): Promise<void> {
+    const stored = await this.database.get<StoredQuestionSetBundle>(
+      TutorIndexedDbStore.ContentQuestionSetBundles,
+      questionSetId
+    );
+    if (!stored) return;
+    const bundle = normalizedBundle(stored.bundle);
+    if (bundle.questionSet.status !== QuestionSetStatus.Ready) return;
+    this.transactionScope.stage(context, {
+      type: 'put',
+      store: TutorIndexedDbStore.ContentQuestionSetBundles,
+      value: {
+        ...stored,
+        bundle: {
+          ...bundle,
+          questionSet: { ...bundle.questionSet, status: QuestionSetStatus.Retired }
+        }
+      } satisfies StoredQuestionSetBundle
+    });
+  }
+
   async applyQuestionSetEnrichment(
     patch: QuestionSetEnrichmentPatch,
     context: TransactionContext
@@ -202,7 +237,10 @@ export class IndexedDbContentRepository implements ContentRepository {
     );
     if (!stored) return false;
     const current = normalizedBundle(stored.bundle);
-    if (current.questionSet.contentVersion !== patch.expectedContentVersion) return false;
+    if (
+      current.questionSet.status !== QuestionSetStatus.Ready
+      || current.questionSet.contentVersion !== patch.expectedContentVersion
+    ) return false;
 
     const questionPatches = new Map(patch.questions.map((question) => [question.id, question]));
     const documentPatches = patch.lecture

--- a/web/src/modules/content/adapters/SqliteContentRepository.ts
+++ b/web/src/modules/content/adapters/SqliteContentRepository.ts
@@ -50,10 +50,9 @@ import type {
   QuestionQualityStatus,
   QuestionSetPracticeStatus,
   QuestionSetPurpose,
-  QuestionSetStatus,
   QuestionTemplateCode
 } from '../domain/ContentCodes';
-import { QuestionSetEntryMode } from '../domain/ContentCodes';
+import { QuestionSetEntryMode, QuestionSetStatus } from '../domain/ContentCodes';
 import { assertCommittedQuestionSetBundle, assertQuestionSetQueryLimit } from '../domain/ContentBundlePolicy';
 import { resolveQuestionSetEntryMode } from '../domain/QuestionSetEntryModePolicy';
 import type {
@@ -311,7 +310,7 @@ export class SqliteContentRepository implements ContentRepository {
 
   async listAllQuestionSets(examCycleId: ExamCycleId): Promise<readonly CommittedQuestionSetBundle[]> {
     const rows = await this.database.query<QuestionSetRow>(
-      `SELECT * FROM question_sets WHERE exam_cycle_id = ? AND status = 'ready'
+      `SELECT * FROM question_sets WHERE exam_cycle_id = ? AND status IN ('ready', 'retired')
        ORDER BY created_at DESC`,
       [examCycleId]
     );
@@ -333,6 +332,13 @@ export class SqliteContentRepository implements ContentRepository {
        SET practice_status = ?
        WHERE id = ? AND practice_status IN (${currentStatuses.map(() => '?').join(', ')})`,
       [status, questionSetId, ...currentStatuses]
+    );
+  }
+
+  async retireQuestionSet(questionSetId: QuestionSetId, context: TransactionContext): Promise<void> {
+    await this.transactionScope.resolve(context).run(
+      `UPDATE question_sets SET status = ? WHERE id = ? AND status = ?`,
+      [QuestionSetStatus.Retired, questionSetId, QuestionSetStatus.Ready]
     );
   }
 

--- a/web/src/modules/content/application/ContentSchemaValidator.ts
+++ b/web/src/modules/content/application/ContentSchemaValidator.ts
@@ -8,6 +8,9 @@ import type {
   DataTableColumn,
   FormulaBlock,
   ImageBlock,
+  StatisticalChartBlock,
+  StatisticalChartPoint,
+  StatisticalChartSeries,
   TextBlock,
   SvgDiagramBlock
 } from '../contracts/ContentDocument';
@@ -31,6 +34,16 @@ const MAX_BLOCK_DEPTH = 4;
 const blockTypes = new Set<string>(Object.values(ContentBlockType));
 const calloutKinds = new Set<string>(Object.values(CalloutKind));
 const alignments = new Set<string>(Object.values(ContentAlignment));
+const statisticalChartTypes = new Set<string>([
+  'bar',
+  'horizontal_bar',
+  'line',
+  'pie',
+  'doughnut',
+  'stacked_bar',
+  'combo',
+  'scatter'
+]);
 
 export class ContentSchemaValidator {
   parseDocument(input: unknown): Result<ContentDocument, ContentValidationFailure> {
@@ -130,6 +143,7 @@ function parseBlock(
     return source === undefined ? undefined : { id, type, source } satisfies TextBlock;
   }
   if (type === ContentBlockType.DataTable) return parseDataTable(id, record, path, issues);
+  if (type === ContentBlockType.StatisticalChart) return parseStatisticalChart(id, record, path, issues);
   if (type === ContentBlockType.SvgDiagram) {
     const markup = readString(record.markup, `${path}.markup`, issues);
     const alt = readString(record.alt, `${path}.alt`, issues);
@@ -219,6 +233,124 @@ function parseDataTable(
     rows: rows as Array<Readonly<Record<string, DataTableCell>>>,
     sourceNote: readOptionalString(record.sourceNote, `${path}.sourceNote`, issues)
   };
+}
+
+function parseStatisticalChart(
+  id: string,
+  record: Record<string, unknown>,
+  path: string,
+  issues: ContentValidationIssue[]
+): StatisticalChartBlock | undefined {
+  const chartType = readString(record.chartType, `${path}.chartType`, issues);
+  if (!chartType || !statisticalChartTypes.has(chartType)) {
+    issue(issues, 'content.chart_type_invalid', `${path}.chartType`, 'Unknown statistical chart type');
+  }
+  const categories = parseChartCategories(record.categories, `${path}.categories`, issues);
+  if (!Array.isArray(record.series) || record.series.length === 0) {
+    issue(issues, 'content.chart_series_invalid', `${path}.series`, 'Chart must contain at least one series');
+    return undefined;
+  }
+  const series = record.series.map((item, index) => parseChartSeries(
+    item,
+    `${path}.series[${index}]`,
+    categories?.length ?? 0,
+    chartType,
+    issues
+  ));
+  const ids = new Set(series.filter(Boolean).map((item) => item!.id));
+  if (ids.size !== series.length) {
+    issue(issues, 'content.chart_series_duplicate', `${path}.series`, 'Chart series ids must be unique');
+  }
+  if (!chartType || !statisticalChartTypes.has(chartType) || !categories || series.some((item) => !item)) {
+    return undefined;
+  }
+  return {
+    id,
+    type: ContentBlockType.StatisticalChart,
+    chartType: chartType as StatisticalChartBlock['chartType'],
+    title: readOptionalString(record.title, `${path}.title`, issues),
+    unit: readOptionalString(record.unit, `${path}.unit`, issues),
+    categories,
+    series: series as StatisticalChartSeries[],
+    sourceNote: readOptionalString(record.sourceNote, `${path}.sourceNote`, issues)
+  };
+}
+
+function parseChartCategories(
+  input: unknown,
+  path: string,
+  issues: ContentValidationIssue[]
+): readonly string[] | undefined {
+  if (!Array.isArray(input)) {
+    issue(issues, 'content.chart_categories_invalid', path, 'Chart categories must be an array');
+    return undefined;
+  }
+  const categories = input.map((item, index) => readString(item, `${path}[${index}]`, issues));
+  return categories.some((item) => !item) ? undefined : categories as string[];
+}
+
+function parseChartSeries(
+  input: unknown,
+  path: string,
+  categoryCount: number,
+  chartType: string | undefined,
+  issues: ContentValidationIssue[]
+): StatisticalChartSeries | undefined {
+  const record = asRecord(input, path, issues);
+  if (!record) return undefined;
+  const id = readString(record.id, `${path}.id`, issues);
+  const label = readString(record.label, `${path}.label`, issues);
+  const renderAs = record.renderAs === 'bar' || record.renderAs === 'line' ? record.renderAs : undefined;
+  if (record.renderAs !== undefined && !renderAs) {
+    issue(issues, 'content.chart_render_type_invalid', `${path}.renderAs`, 'Series render type must be bar or line');
+  }
+  if (chartType === 'scatter') {
+    const points = parseChartPoints(record.points, `${path}.points`, issues);
+    return id && label && points ? { id, label, points } : undefined;
+  }
+  if (!Array.isArray(record.values) || record.values.length !== categoryCount || categoryCount === 0) {
+    issue(
+      issues,
+      'content.chart_values_invalid',
+      `${path}.values`,
+      'Series values must match the category count'
+    );
+    return undefined;
+  }
+  const values = record.values.map((value, index) => {
+    if (value !== null && typeof value !== 'number') {
+      issue(issues, 'content.chart_value_invalid', `${path}.values[${index}]`, 'Chart value must be a number or null');
+      return undefined;
+    }
+    return value;
+  });
+  if (!id || !label || values.some((value) => value === undefined)) return undefined;
+  return { id, label, values: values as Array<number | null>, ...(renderAs ? { renderAs } : {}) };
+}
+
+function parseChartPoints(
+  input: unknown,
+  path: string,
+  issues: ContentValidationIssue[]
+): readonly StatisticalChartPoint[] | undefined {
+  if (!Array.isArray(input) || input.length === 0) {
+    issue(issues, 'content.chart_points_invalid', path, 'Scatter series must contain points');
+    return undefined;
+  }
+  const points = input.map((item, index) => {
+    const record = asRecord(item, `${path}[${index}]`, issues);
+    if (!record) return undefined;
+    if (typeof record.x !== 'number' || typeof record.y !== 'number') {
+      issue(issues, 'content.chart_point_invalid', `${path}[${index}]`, 'Chart point requires numeric x and y');
+      return undefined;
+    }
+    return {
+      x: record.x,
+      y: record.y,
+      label: readOptionalString(record.label, `${path}[${index}].label`, issues)
+    } satisfies StatisticalChartPoint;
+  });
+  return points.some((point) => !point) ? undefined : points as StatisticalChartPoint[];
 }
 
 function parseColumn(input: unknown, path: string, issues: ContentValidationIssue[]): DataTableColumn | undefined {

--- a/web/src/modules/content/application/GeneratedContentAuthoringUtils.ts
+++ b/web/src/modules/content/application/GeneratedContentAuthoringUtils.ts
@@ -1,0 +1,56 @@
+export interface AuthoringVisual {
+  readonly svg: string;
+  readonly alt: string;
+  readonly viewBox?: string;
+}
+
+export function decodeEmbeddedJson(input: unknown): unknown {
+  if (typeof input !== 'string') return input;
+  const source = input.trim();
+  if (!source.startsWith('{') && !source.startsWith('[')) return input;
+  try {
+    const parsed: unknown = JSON.parse(source);
+    return parsed && typeof parsed === 'object' ? parsed : input;
+  } catch {
+    return input;
+  }
+}
+
+export function asOptionalRecord(input: unknown): Record<string, unknown> | undefined {
+  return input && typeof input === 'object' && !Array.isArray(input)
+    ? input as Record<string, unknown>
+    : undefined;
+}
+
+export function optionalAuthorTextValue(input: unknown): string | undefined {
+  return typeof input === 'string' && input.trim() ? input.trim() : undefined;
+}
+
+export function authoringVisual(input: unknown): AuthoringVisual | undefined {
+  const value = asOptionalRecord(decodeEmbeddedJson(input));
+  if (
+    typeof value?.svg !== 'string'
+    || !/^\s*<svg(?:\s|>)[\s\S]*<\/svg>\s*$/i.test(value.svg)
+    || typeof value.alt !== 'string'
+    || !value.alt.trim()
+  ) {
+    return undefined;
+  }
+  return {
+    svg: value.svg.trim(),
+    alt: value.alt.trim(),
+    viewBox: typeof value.viewBox === 'string' && value.viewBox.trim() ? value.viewBox.trim() : undefined
+  };
+}
+
+export function normalizeAuthoringSvg(markup: string, viewBox?: string): string {
+  if (/\bviewBox\s*=\s*["'][^"']+["']/i.test(markup)) return markup;
+  const resolvedViewBox = viewBox?.trim() || inferredSvgViewBox(markup) || '0 0 100 100';
+  return markup.replace(/<svg(\s|>)/i, `<svg viewBox="${resolvedViewBox}"$1`);
+}
+
+function inferredSvgViewBox(markup: string): string | undefined {
+  const width = markup.match(/\bwidth\s*=\s*["']([\d.]+)["']/i)?.[1];
+  const height = markup.match(/\bheight\s*=\s*["']([\d.]+)["']/i)?.[1];
+  return width && height ? `0 0 ${width} ${height}` : undefined;
+}

--- a/web/src/modules/content/application/GeneratedContentParser.ts
+++ b/web/src/modules/content/application/GeneratedContentParser.ts
@@ -3,6 +3,15 @@ import type { JsonObject } from '@/kernel/public';
 import type { ContentDocument } from '../contracts/ContentDocument';
 import type { SingleChoiceQuestionContent } from '../contracts/QuestionContent';
 import { ContentSchemaValidator, type ContentValidationIssue } from './ContentSchemaValidator';
+import {
+  asOptionalRecord,
+  authoringVisual,
+  decodeEmbeddedJson,
+  normalizeAuthoringSvg,
+  optionalAuthorTextValue,
+  type AuthoringVisual
+} from './GeneratedContentAuthoringUtils';
+import { authoringMaterialGroups } from './GeneratedMaterialBlockParser';
 
 export interface GeneratedLectureQuestionSet {
   readonly raw: JsonObject;
@@ -106,18 +115,6 @@ function asRecord(input: unknown): Record<string, unknown> {
   return input as Record<string, unknown>;
 }
 
-function decodeEmbeddedJson(input: unknown): unknown {
-  if (typeof input !== 'string') return input;
-  const source = input.trim();
-  if (!source.startsWith('{') && !source.startsWith('[')) return input;
-  try {
-    const parsed: unknown = JSON.parse(source);
-    return parsed && typeof parsed === 'object' ? parsed : input;
-  } catch {
-    return input;
-  }
-}
-
 function normalizeAuthoringRoot(
   root: Record<string, unknown>,
   expectedCapabilityCode?: string
@@ -189,7 +186,7 @@ function authoringSection(
 function authoringQuestion(
   input: unknown,
   index: number,
-  materialGroups: ReadonlyMap<string, string>,
+  materialGroups: ReadonlyMap<string, Record<string, unknown>>,
   materialGroupUseCounts: ReadonlyMap<string, number>,
   expectedCapabilityCode: string | undefined,
   issues: ContentValidationIssue[]
@@ -427,23 +424,6 @@ function calloutBlock(id: string, kind: string, title: string, source: string): 
   };
 }
 
-function authoringMaterialGroups(
-  input: unknown
-): ReadonlyMap<string, string> {
-  if (input === undefined) return new Map();
-  if (!Array.isArray(input)) return new Map();
-  const groups = new Map<string, string>();
-  input.forEach((item) => {
-    const group = asOptionalRecord(decodeEmbeddedJson(item));
-    if (!group) return;
-    const id = optionalAuthorTextValue(group.id);
-    const markdown = optionalAuthorTextValue(group.markdown);
-    if (!id || !markdown) return;
-    if (!groups.has(id)) groups.set(id, markdown);
-  });
-  return groups;
-}
-
 function authorDocument(id: string, source: string): Record<string, unknown> {
   return {
     schemaVersion: 'content.v1',
@@ -453,12 +433,6 @@ function authorDocument(id: string, source: string): Record<string, unknown> {
 
 function emptyDocument(id: string): ContentDocument {
   return { schemaVersion: 'content.v1', blocks: [{ id, type: 'text', source: '' }] };
-}
-
-interface AuthoringVisual {
-  readonly svg: string;
-  readonly alt: string;
-  readonly viewBox?: string;
 }
 
 function authorDocumentWithVisual(
@@ -481,35 +455,6 @@ function authorDocumentWithVisual(
   };
 }
 
-function authoringVisual(input: unknown): AuthoringVisual | undefined {
-  const value = asOptionalRecord(decodeEmbeddedJson(input));
-  if (
-    typeof value?.svg !== 'string'
-    || !/^\s*<svg(?:\s|>)[\s\S]*<\/svg>\s*$/i.test(value.svg)
-    || typeof value.alt !== 'string'
-    || !value.alt.trim()
-  ) {
-    return undefined;
-  }
-  return {
-    svg: value.svg.trim(),
-    alt: value.alt.trim(),
-    viewBox: typeof value.viewBox === 'string' && value.viewBox.trim() ? value.viewBox.trim() : undefined
-  };
-}
-
-function normalizeAuthoringSvg(markup: string, viewBox?: string): string {
-  if (/\bviewBox\s*=\s*["'][^"']+["']/i.test(markup)) return markup;
-  const resolvedViewBox = viewBox?.trim() || inferredSvgViewBox(markup) || '0 0 100 100';
-  return markup.replace(/<svg(\s|>)/i, `<svg viewBox="${resolvedViewBox}"$1`);
-}
-
-function inferredSvgViewBox(markup: string): string | undefined {
-  const width = markup.match(/\bwidth\s*=\s*["']([\d.]+)["']/i)?.[1];
-  const height = markup.match(/\bheight\s*=\s*["']([\d.]+)["']/i)?.[1];
-  return width && height ? `0 0 ${width} ${height}` : undefined;
-}
-
 function requiredAuthorText(
   input: unknown,
   path: string,
@@ -518,14 +463,4 @@ function requiredAuthorText(
   if (typeof input === 'string' && input.trim()) return input.trim();
   issues.push({ code: 'generation.author_text_invalid', path, message: 'Expected a non-empty string' });
   return undefined;
-}
-
-function optionalAuthorTextValue(input: unknown): string | undefined {
-  return typeof input === 'string' && input.trim() ? input.trim() : undefined;
-}
-
-function asOptionalRecord(input: unknown): Record<string, unknown> | undefined {
-  return input && typeof input === 'object' && !Array.isArray(input)
-    ? input as Record<string, unknown>
-    : undefined;
 }

--- a/web/src/modules/content/application/GeneratedMaterialBlockParser.ts
+++ b/web/src/modules/content/application/GeneratedMaterialBlockParser.ts
@@ -1,0 +1,150 @@
+import {
+  asOptionalRecord,
+  authoringVisual,
+  decodeEmbeddedJson,
+  normalizeAuthoringSvg,
+  optionalAuthorTextValue
+} from './GeneratedContentAuthoringUtils';
+
+export function authoringMaterialGroups(input: unknown): ReadonlyMap<string, Record<string, unknown>> {
+  if (!Array.isArray(input)) return new Map();
+  const groups = new Map<string, Record<string, unknown>>();
+  input.forEach((item) => {
+    const group = asOptionalRecord(decodeEmbeddedJson(item));
+    if (!group) return;
+    const id = optionalAuthorTextValue(group.id);
+    const markdown = optionalAuthorTextValue(group.markdown);
+    if (!id || !markdown || groups.has(id)) return;
+    groups.set(id, authorMaterialDocument(id, markdown, group.table, group.chart, group.visual));
+  });
+  return groups;
+}
+
+function authorMaterialDocument(
+  id: string,
+  markdown: string,
+  tableInput: unknown,
+  chartInput: unknown,
+  visualInput: unknown
+): Record<string, unknown> {
+  const table = authoringTable(`${id}:table`, tableInput);
+  const chart = authoringChart(`${id}:chart`, chartInput);
+  const visual = authoringVisual(visualInput);
+  return {
+    schemaVersion: 'content.v1',
+    blocks: [
+      { id: `${id}:text`, type: 'text', source: markdown },
+      ...(table ? [table] : []),
+      ...(chart ? [chart] : []),
+      ...(visual ? [{
+        id: `${id}:visual`,
+        type: 'svg_diagram',
+        markup: normalizeAuthoringSvg(visual.svg, visual.viewBox),
+        alt: visual.alt,
+        ...(visual.viewBox ? { viewBox: visual.viewBox } : {}),
+        fit: 'contain'
+      }] : [])
+    ]
+  };
+}
+
+const authoringChartTypes = new Set([
+  'bar',
+  'horizontal_bar',
+  'line',
+  'pie',
+  'doughnut',
+  'stacked_bar',
+  'combo',
+  'scatter'
+]);
+
+function authoringChart(id: string, input: unknown): Record<string, unknown> | undefined {
+  const chart = asOptionalRecord(decodeEmbeddedJson(input));
+  if (!chart || typeof chart.type !== 'string' || !authoringChartTypes.has(chart.type)) return undefined;
+  if (!Array.isArray(chart.categories) || !Array.isArray(chart.series) || !chart.series.length) return undefined;
+  const categories = chart.categories.flatMap((item) => (
+    typeof item === 'string' && item.trim() ? [item.trim()] : []
+  ));
+  if (categories.length !== chart.categories.length) return undefined;
+  const series: Record<string, unknown>[] = [];
+  chart.series.forEach((item, index) => {
+    const record = asOptionalRecord(item);
+    const label = optionalAuthorTextValue(record?.label);
+    if (!record || !label) return;
+    if (chart.type === 'scatter') {
+      if (!Array.isArray(record.points)) return;
+      const points = record.points.flatMap((point) => {
+        const value = asOptionalRecord(point);
+        return typeof value?.x === 'number' && typeof value.y === 'number'
+          ? [{
+              x: value.x,
+              y: value.y,
+              ...(optionalAuthorTextValue(value.label) ? { label: optionalAuthorTextValue(value.label) } : {})
+            }]
+          : [];
+      });
+      if (points.length === record.points.length && points.length) {
+        series.push({ id: `series_${index + 1}`, label, points });
+      }
+      return;
+    }
+    if (!Array.isArray(record.values) || record.values.length !== categories.length || !categories.length) return;
+    const values = record.values.filter((value) => value === null || typeof value === 'number');
+    if (values.length !== record.values.length) return;
+    const renderAs = record.renderAs === 'bar' || record.renderAs === 'line' ? record.renderAs : undefined;
+    series.push({
+      id: `series_${index + 1}`,
+      label,
+      values,
+      ...(renderAs ? { renderAs } : {})
+    });
+  });
+  if (series.length !== chart.series.length) return undefined;
+  return {
+    id,
+    type: 'statistical_chart',
+    chartType: chart.type,
+    ...(optionalAuthorTextValue(chart.title) ? { title: optionalAuthorTextValue(chart.title) } : {}),
+    ...(optionalAuthorTextValue(chart.unit) ? { unit: optionalAuthorTextValue(chart.unit) } : {}),
+    categories,
+    series,
+    ...(optionalAuthorTextValue(chart.sourceNote) ? { sourceNote: optionalAuthorTextValue(chart.sourceNote) } : {})
+  };
+}
+
+function authoringTable(id: string, input: unknown): Record<string, unknown> | undefined {
+  const table = asOptionalRecord(decodeEmbeddedJson(input));
+  if (!table || !Array.isArray(table.columns) || !Array.isArray(table.rows)) return undefined;
+  const columns = table.columns.flatMap((item, index) => {
+    const column = asOptionalRecord(item);
+    const label = optionalAuthorTextValue(column?.label);
+    if (!label) return [];
+    const alignment = column?.alignment === 'left' || column?.alignment === 'center' || column?.alignment === 'right'
+      ? column.alignment
+      : index === 0 ? 'left' : 'right';
+    const valueType = column?.valueType === 'text' || column?.valueType === 'number' || column?.valueType === 'percent'
+      ? column.valueType
+      : index === 0 ? 'text' : 'number';
+    return [{ key: `column_${index + 1}`, label, alignment, valueType }];
+  });
+  if (columns.length < 2 || columns.length !== table.columns.length) return undefined;
+  const rows = table.rows.flatMap((item) => {
+    if (!Array.isArray(item) || item.length !== columns.length) return [];
+    const cells = item.map((cell) => (
+      cell === null || typeof cell === 'string' || typeof cell === 'number' ? cell : undefined
+    ));
+    if (cells.some((cell) => cell === undefined)) return [];
+    return [Object.fromEntries(columns.map((column, index) => [column.key, cells[index] ?? null]))];
+  });
+  if (!rows.length) return undefined;
+  return {
+    id,
+    type: 'data_table',
+    ...(optionalAuthorTextValue(table.caption) ? { caption: optionalAuthorTextValue(table.caption) } : {}),
+    ...(optionalAuthorTextValue(table.unit) ? { unit: optionalAuthorTextValue(table.unit) } : {}),
+    columns,
+    rows,
+    ...(optionalAuthorTextValue(table.sourceNote) ? { sourceNote: optionalAuthorTextValue(table.sourceNote) } : {})
+  };
+}

--- a/web/src/modules/content/application/PracticeCoreGenerationPolicy.ts
+++ b/web/src/modules/content/application/PracticeCoreGenerationPolicy.ts
@@ -121,7 +121,8 @@ export function practiceCoreSystem(system: string, capabilityCode = ''): string 
  */
 export function practiceCoreResponseSchema(
   schema: JsonObject,
-  exactQuestionCount?: number
+  exactQuestionCount?: number,
+  capabilityCode = ''
 ): JsonObject {
   const cloned = JSON.parse(JSON.stringify(schema)) as Record<string, unknown>;
   const properties = schemaRecord(cloned.properties, '$.properties');
@@ -157,6 +158,17 @@ export function practiceCoreResponseSchema(
       knowledgePoint: { type: 'string', minLength: 2 }
     }
   };
+  if (!capabilityCode.startsWith('aptitude.data_analysis.')) {
+    const materialGroups = schemaRecord(properties.materialGroups, '$.properties.materialGroups');
+    const materialGroup = schemaRecord(materialGroups.items, '$.properties.materialGroups.items');
+    const materialGroupProperties = schemaRecord(
+      materialGroup.properties,
+      '$.properties.materialGroups.items.properties'
+    );
+    delete materialGroupProperties.table;
+    delete materialGroupProperties.chart;
+    delete materialGroupProperties.visual;
+  }
   return cloned as JsonObject;
 }
 
@@ -184,7 +196,7 @@ export function practiceQuestionShardResponseSchema(
   exactQuestionCount: number,
   capabilityCode = ''
 ): JsonObject {
-  const cloned = practiceCoreResponseSchema(schema, exactQuestionCount) as Record<string, unknown>;
+  const cloned = practiceCoreResponseSchema(schema, exactQuestionCount, capabilityCode) as Record<string, unknown>;
   const properties = schemaRecord(cloned.properties, '$.properties');
   delete properties.lecture;
   cloned.required = (Array.isArray(cloned.required) ? cloned.required : [])
@@ -224,7 +236,9 @@ function capabilityStructuralContract(capabilityCode: string): string {
   if (capabilityCode.startsWith('aptitude.data_analysis.')) {
     return [
       '本次是资料分析题。使用一个完整 materialGroups 公共资料承载数据表或统计材料，至少两道小题引用同一个 materialGroupId。',
-      '公共资料中的表格使用标准 GFM Markdown，表头、分隔行和数据行必须完整；每道小题的 material 必须为 null。',
+      '表格资料写入 materialGroups.table：columns 按展示顺序定义列，rows 按相同顺序填写单元格。柱状图、折线图、饼图、堆叠图、组合图和散点图写入 materialGroups.chart，由应用按原始数据统一绘制。',
+      '只有无法用 table 或 chart 表达的特殊示意图才写入 materialGroups.visual，并提供完整 SVG 与 viewBox。materialGroups.markdown 只保存标题、资料说明和来源注记，不重复结构化块已承载的数据。',
+      'chart.categories 与每组 series.values 数量必须一致；组合图通过 renderAs 指定 bar 或 line；散点图使用 points。无法结构化时才使用完整标准 GFM Markdown 表格兜底。',
       '题干只保留当前小题的设问，选项只保留当前小题的候选答案，不要把资料表重复写入各题。'
     ].join('\n');
   }

--- a/web/src/modules/content/application/RetireQuestionSet.ts
+++ b/web/src/modules/content/application/RetireQuestionSet.ts
@@ -1,0 +1,18 @@
+import type { UnitOfWork } from '@/capabilities/database/public';
+import type { QuestionSetId } from '@/kernel/public';
+import type { ContentRepository } from '../contracts/ContentRepository';
+import { QuestionSetStatus } from '../domain/ContentCodes';
+
+export class RetireQuestionSet {
+  constructor(
+    private readonly unitOfWork: UnitOfWork,
+    private readonly repository: ContentRepository
+  ) {}
+
+  async execute(questionSetId: QuestionSetId): Promise<boolean> {
+    const bundle = await this.repository.findQuestionSet(questionSetId);
+    if (!bundle || bundle.questionSet.status !== QuestionSetStatus.Ready) return false;
+    await this.unitOfWork.run((context) => this.repository.retireQuestionSet(questionSetId, context));
+    return true;
+  }
+}

--- a/web/src/modules/content/application/RunStructuredObjectiveGenerationWorkflow.ts
+++ b/web/src/modules/content/application/RunStructuredObjectiveGenerationWorkflow.ts
@@ -313,7 +313,7 @@ export class RunStructuredObjectiveGenerationWorkflow {
       signal,
       expectedCount,
       system: practiceCoreSystem(compiled.system, capability),
-      responseSchema: practiceCoreResponseSchema(compiled.responseSchema, expectedCount),
+      responseSchema: practiceCoreResponseSchema(compiled.responseSchema, expectedCount, capability),
       role: 'content_generation',
       allowValidSubset: true,
       onProgress

--- a/web/src/modules/content/contracts/ContentDocument.ts
+++ b/web/src/modules/content/contracts/ContentDocument.ts
@@ -34,6 +34,40 @@ export interface DataTableBlock extends ContentBlockBase {
   readonly sourceNote?: string;
 }
 
+export type StatisticalChartType =
+  | 'bar'
+  | 'horizontal_bar'
+  | 'line'
+  | 'pie'
+  | 'doughnut'
+  | 'stacked_bar'
+  | 'combo'
+  | 'scatter';
+
+export interface StatisticalChartPoint {
+  readonly x: number;
+  readonly y: number;
+  readonly label?: string;
+}
+
+export interface StatisticalChartSeries {
+  readonly id: string;
+  readonly label: string;
+  readonly values?: readonly (number | null)[];
+  readonly points?: readonly StatisticalChartPoint[];
+  readonly renderAs?: 'bar' | 'line';
+}
+
+export interface StatisticalChartBlock extends ContentBlockBase {
+  readonly type: 'statistical_chart';
+  readonly chartType: StatisticalChartType;
+  readonly title?: string;
+  readonly unit?: string;
+  readonly categories: readonly string[];
+  readonly series: readonly StatisticalChartSeries[];
+  readonly sourceNote?: string;
+}
+
 export interface SvgDiagramBlock extends ContentBlockBase {
   readonly type: 'svg_diagram';
   readonly markup: string;
@@ -65,6 +99,7 @@ export interface CalloutBlock extends ContentBlockBase {
 export type ContentBlock =
   | TextBlock
   | DataTableBlock
+  | StatisticalChartBlock
   | SvgDiagramBlock
   | ImageBlock
   | FormulaBlock

--- a/web/src/modules/content/contracts/ContentRepository.ts
+++ b/web/src/modules/content/contracts/ContentRepository.ts
@@ -288,12 +288,14 @@ export interface ContentRepository {
   ): Promise<readonly QuestionSetLibraryEntry[]>;
   queryQuestionSetLibrary(query: QuestionSetLibraryQuery): Promise<readonly QuestionSetLibraryEntry[]>;
   listQuestionSets(examCycleId: ExamCycleId, limit: number): Promise<readonly CommittedQuestionSetBundle[]>;
+  /** Includes ready and retired sets so backups retain content referenced by completed learning facts. */
   listAllQuestionSets(examCycleId: ExamCycleId): Promise<readonly CommittedQuestionSetBundle[]>;
   updateQuestionSetPracticeStatus(
     questionSetId: QuestionSetId,
     status: QuestionSetPracticeStatus,
     context: TransactionContext
   ): Promise<void>;
+  retireQuestionSet(questionSetId: QuestionSetId, context: TransactionContext): Promise<void>;
   applyQuestionSetEnrichment(
     patch: QuestionSetEnrichmentPatch,
     context: TransactionContext

--- a/web/src/modules/content/domain/ContentCodes.ts
+++ b/web/src/modules/content/domain/ContentCodes.ts
@@ -1,6 +1,7 @@
 export const ContentBlockType = {
   Text: 'text',
   DataTable: 'data_table',
+  StatisticalChart: 'statistical_chart',
   SvgDiagram: 'svg_diagram',
   Image: 'image',
   Formula: 'formula',

--- a/web/src/modules/content/domain/ContentDocumentText.ts
+++ b/web/src/modules/content/domain/ContentDocumentText.ts
@@ -13,6 +13,15 @@ export function contentBlockText(block: ContentBlock): string {
     ));
     return [block.caption ?? '', header, ...rows, block.sourceNote ?? ''].filter(Boolean).join('\n');
   }
+  if (block.type === 'statistical_chart') {
+    const categories = block.categories.join('、');
+    const series = block.series.map((item) => {
+      const values = item.values?.map((value) => value ?? '').join('、');
+      const points = item.points?.map((point) => `${point.label ?? point.x}: ${point.y}`).join('、');
+      return `${item.label}: ${values || points || ''}`;
+    });
+    return [block.title ?? '', categories, ...series, block.sourceNote ?? ''].filter(Boolean).join('\n');
+  }
   if (block.type === 'svg_diagram' || block.type === 'image') return block.alt;
   if (block.type === 'formula') return block.source;
   return [block.title ?? '', ...block.blocks.map((child) => contentBlockText(child))].filter(Boolean).join('\n');

--- a/web/src/modules/content/domain/QuestionPresentation.ts
+++ b/web/src/modules/content/domain/QuestionPresentation.ts
@@ -81,6 +81,7 @@ export function questionRegionOrder(layout: QuestionRegionLayoutCode): readonly 
 
 function hasDataTable(document: ContentDocument): boolean {
   return document.blocks.some((block) => blockHasType(block, ContentBlockType.DataTable)
+    || blockHasType(block, ContentBlockType.StatisticalChart)
     || (block.type === ContentBlockType.Text && markdownTablePattern.test(block.source)));
 }
 

--- a/web/src/modules/content/public.ts
+++ b/web/src/modules/content/public.ts
@@ -111,6 +111,10 @@ export type {
   DataTableBlock,
   DataTableCell,
   DataTableColumn,
+  StatisticalChartBlock,
+  StatisticalChartPoint,
+  StatisticalChartSeries,
+  StatisticalChartType,
   FormulaBlock,
   ImageBlock,
   TextBlock,
@@ -131,6 +135,7 @@ export {
   ApplyQuestionSetEnrichment,
   type ApplyQuestionSetEnrichmentResult
 } from './application/ApplyQuestionSetEnrichment';
+export { RetireQuestionSet } from './application/RetireQuestionSet';
 export { questionSetPracticeStatusLabel } from './domain/QuestionSetPracticePresentation';
 export type {
   QuestionContent,

--- a/web/src/services/StudyService.ts
+++ b/web/src/services/StudyService.ts
@@ -1,8 +1,10 @@
 import { initializeTutorRuntime } from '@/composition-root/public';
 import { CapabilityNodeType, type CapabilityNode } from '@/modules/curriculum/public';
-import { LearningAssetKind, LearningAssetStatus } from '@/modules/content/public';
+import { LearningAssetKind, LearningAssetStatus, type LearningAssetRecord } from '@/modules/content/public';
 import { LearningProgressStatus, LearningResourceType } from '@/modules/learning-progress/public';
+import type { AgentRunView } from '@/modules/agent/public';
 import { practiceModuleCode, practiceModuleLabel } from '@/domain/labels';
+import { STUDY_LECTURE_DEFAULT_MODULE, studyLectureBusinessKey } from '@/domain/studyLecture';
 import {
   CapabilityRecommendationMode,
   LearnerPriorityAction,
@@ -53,6 +55,15 @@ export interface DailyPlanLearningContext {
   readonly dailyPlanItemId: string;
   readonly capabilityNodeId?: string;
 }
+
+/**
+ * Outcome of asking for a knowledge point's lecture: either one already exists
+ * and can be opened straight away, or a run is now writing it. Callers branch
+ * on this instead of assuming every request costs a generation.
+ */
+export type StudyLectureEntry =
+  | { readonly kind: 'ready'; readonly assetId: string; readonly capabilityNodeId?: string }
+  | { readonly kind: 'generating'; readonly task: AgentRunView };
 
 function score(value: number | undefined, fallback = 0): number {
   return Math.round(Math.max(0, Math.min(1, value ?? fallback)) * 100);
@@ -176,14 +187,36 @@ export class StudyService {
     });
   }
 
+  /**
+   * Opens the lecture for a knowledge point, generating one only when none is
+   * stored yet.
+   *
+   * A lecture is keyed by its knowledge point, so revisiting a point should
+   * reopen what was already written rather than pay for a fresh generation and
+   * make the reader wait through it again. `regenerate` is the explicit escape
+   * hatch for wanting a different take on the same point.
+   */
   async startLearning(
     point: Pick<StudyPoint, 'module' | 'name' | 'capabilityNodeId'> | { module?: string; name: string; capabilityNodeId?: string },
-    planContext?: DailyPlanLearningContext
-  ) {
-    const sourceModule = point.module || '公考';
+    planContext?: DailyPlanLearningContext,
+    options: { readonly regenerate?: boolean } = {}
+  ): Promise<StudyLectureEntry> {
+    const sourceModule = point.module || STUDY_LECTURE_DEFAULT_MODULE;
     const module = practiceModuleLabel(sourceModule);
     const moduleCode = practiceModuleCode(sourceModule) || sourceModule;
-    return generationTaskService.enqueue({
+    if (!options.regenerate) {
+      const stored = await this.findReadyLecture(studyLectureBusinessKey(moduleCode, point.name));
+      if (stored) {
+        return {
+          kind: 'ready',
+          assetId: stored.id,
+          capabilityNodeId: payloadString(stored.payload.capabilityNodeId)
+            || point.capabilityNodeId
+            || planContext?.capabilityNodeId
+        };
+      }
+    }
+    const enqueued = await generationTaskService.enqueue({
       intent: 'study',
       title: '生成考点精讲',
       detail: `${module} · ${point.name}`,
@@ -201,9 +234,27 @@ export class StudyService {
         } : {})
       }
     });
+    return { kind: 'generating', task: enqueued.task };
   }
 
-  async startDailyPlanLecture(context: DailyPlanLearningContext) {
+  /** A stored lecture only counts as reusable once it actually carries content. */
+  private async findReadyLecture(businessKey: string): Promise<LearningAssetRecord | undefined> {
+    const runtime = await initializeTutorRuntime();
+    const cycle = await runtime.candidateRepository.findCurrentCycle();
+    if (!cycle) return undefined;
+    const asset = await runtime.learningAssetStore.findLatest(
+      cycle.examCycle.id,
+      LearningAssetKind.StudyLecture,
+      businessKey
+    );
+    if (!asset || asset.status !== LearningAssetStatus.Ready) return undefined;
+    return payloadString(asset.payload.content) ? asset : undefined;
+  }
+
+  async startDailyPlanLecture(
+    context: DailyPlanLearningContext,
+    options: { readonly regenerate?: boolean } = {}
+  ): Promise<StudyLectureEntry> {
     const runtime = await initializeTutorRuntime();
     const cycle = await runtime.candidateRepository.findCurrentCycle();
     if (!cycle) throw new Error('请先完成备考档案。');
@@ -213,10 +264,10 @@ export class StudyService {
     if (!node || !curriculum) throw new Error('今日计划对应考点已失效，请刷新计划后重试。');
     const byId = new Map(curriculum.capabilityNodes.map((candidate) => [candidate.id, candidate]));
     return this.startLearning({
-      module: moduleAncestor(node, byId)?.name || node.module || '公考',
+      module: moduleAncestor(node, byId)?.name || node.module || STUDY_LECTURE_DEFAULT_MODULE,
       name: node.name,
       capabilityNodeId: node.id
-    }, context);
+    }, context, options);
   }
 
   async markLectureStarted(input: {

--- a/web/src/views/DigestView.vue
+++ b/web/src/views/DigestView.vue
@@ -419,17 +419,6 @@ function localDate(): string {
 
 .digest-body {
   color: var(--text-secondary-color);
-  font-size: var(--type-size-secondary);
-}
-
-.digest-body :deep(h3),
-.digest-body :deep(h4) {
-  margin-top: 13px;
-  color: var(--text-color);
-}
-
-.digest-body :deep(strong) {
-  color: var(--text-color);
 }
 
 .digest-history-list {

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -193,6 +193,7 @@ import {
   TargetIcon
 } from 'lucide-vue-next';
 import PageHeader from '@/components/layout/PageHeader.vue';
+import { useCachedViewRefresh } from '@/components/layout/useCachedViewRefresh';
 import { AppStateView, PullToRefresh, SectionHeading } from '@/capabilities/design-system/public';
 import HomeActionGrid from '@/features/home/HomeActionGrid.vue';
 import { practiceDetailLocation } from '@/features/practice/PracticeNavigation';
@@ -216,6 +217,9 @@ import {
 import type { LearnerPriorityResult } from '@/modules/mastery/public';
 import { qualityDashboardService, type QualityDashboard } from '@/services/QualityDashboardService';
 
+// Named so App.vue can hold this tab root in its <KeepAlive> whitelist.
+defineOptions({ name: 'HomeView' });
+
 const router = useRouter();
 const candidateHome = ref<CandidateHomeSnapshot | null>(null);
 const quality = ref<QualityDashboard | null>(null);
@@ -231,6 +235,9 @@ const {
 const isTutorLoading = ref(true);
 const tutorLoadError = ref('');
 onMounted(loadTutorHome);
+// Reloading keeps the rendered home on screen: loadTutorHome only raises the
+// skeleton while there is no candidate home to show yet.
+useCachedViewRefresh(loadTutorHome);
 async function loadTutorHome() {
   const showInitialLoading = !candidateHome.value;
   if (showInitialLoading) isTutorLoading.value = true;

--- a/web/src/views/LearningCenterView.vue
+++ b/web/src/views/LearningCenterView.vue
@@ -138,13 +138,19 @@ import { AppStateView, PullToRefresh, SectionHeading } from '@/capabilities/desi
 import { digestService } from '@/services/DigestService';
 import { studyService, type StudyDashboard, type StudyPoint } from '@/services/StudyService';
 import { essayCenterLocation } from '@/features/practice/EssayNavigation';
+import { useCachedViewRefresh } from '@/components/layout/useCachedViewRefresh';
 import { CapabilityRecommendationMode } from '@/modules/mastery/public';
+
+// Named so App.vue can hold this tab root in its <KeepAlive> whitelist.
+defineOptions({ name: 'LearningCenterView' });
 
 const router = useRouter();
 const studyDashboard = ref<StudyDashboard | null>(null);
 const digestCount = ref(0);
 const digestCompleted = ref(false);
-const isLoading = ref(false);
+// True from the start: the first frame runs before onMounted dispatches the
+// load, and a false default left that frame with no state branch to render.
+const isLoading = ref(true);
 const loadError = ref('');
 const preferenceDialogOpen = ref(false);
 const preferencePoint = ref<StudyPoint>();
@@ -208,6 +214,9 @@ const practiceItems = [
 ];
 
 onMounted(loadDashboard);
+// Reloading keeps the rendered advice on screen: loadDashboard only raises the
+// loading state while there is no dashboard to show yet.
+useCachedViewRefresh(loadDashboard);
 
 async function loadDashboard() {
   if (!studyDashboard.value) isLoading.value = true;
@@ -228,11 +237,13 @@ async function loadDashboard() {
 }
 
 async function learn(point: StudyPoint) {
-  const result = await studyService.startLearning(point);
+  const entry = await studyService.startLearning(point);
   await router.push({
     path: '/vue/study/lecture',
     query: {
-      taskId: result.task.id,
+      // A point that already has a lecture opens it directly; only a genuinely
+      // new point routes through the generation task.
+      ...(entry.kind === 'ready' ? { assetId: entry.assetId } : { taskId: entry.task.id }),
       capabilityNodeId: point.capabilityNodeId,
       source: 'learning-center'
     }

--- a/web/src/views/ProfileView.vue
+++ b/web/src/views/ProfileView.vue
@@ -314,6 +314,7 @@
 import { computed, onMounted, reactive, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import PageHeader from '@/components/layout/PageHeader.vue';
+import { useCachedViewRefresh } from '@/components/layout/useCachedViewRefresh';
 import WebResearchSettingsFields from '@/components/settings/WebResearchSettingsFields.vue';
 import BottomSheet from '@/components/layout/BottomSheet.vue';
 import ConfirmDialog from '@/components/layout/ConfirmDialog.vue';
@@ -365,6 +366,10 @@ import {
   CandidateProfileFeature,
   peekCandidateProfileSnapshot
 } from '@/features/profile/CandidateProfileFeature';
+
+// Named so App.vue can hold this tab root in its <KeepAlive> whitelist.
+defineOptions({ name: 'ProfileView' });
+
 const router = useRouter();
 let candidateProfileFeaturePromise: Promise<CandidateProfileFeature> | undefined;
 const cachedCandidateSnapshot = peekCandidateProfileSnapshot();
@@ -485,6 +490,16 @@ onMounted(() => {
   void loadAIConfig();
   void loadReminderStatus();
   void loadProfileStats();
+});
+
+/**
+ * Only the learning-derived panels are reloaded on return. The provider and
+ * reminder forms are edited on this page and their inputs survive in the view
+ * cache, so re-reading them would overwrite whatever the user had typed before
+ * switching tabs.
+ */
+useCachedViewRefresh(async () => {
+  await Promise.all([loadCandidateHome(), loadProfileStats()]);
 });
 
 async function loadProfileStats() {

--- a/web/src/views/StudyView.vue
+++ b/web/src/views/StudyView.vue
@@ -45,6 +45,15 @@
           <CheckCircle2Icon />{{ isCompleting ? '正在更新计划' : '完成本节' }}
         </button>
         <p v-else class="completion-notice"><CheckCircle2Icon />本节已完成，下一步请用练习验证掌握</p>
+        <button
+          v-if="loadedTopic"
+          type="button"
+          class="regenerate-lecture-button"
+          :disabled="isDispatching"
+          @click="regenerateLecture"
+        >
+          <RefreshCwIcon />{{ isDispatching ? '正在重新生成' : '换一版讲义' }}
+        </button>
       </template>
       <template v-else-if="dashboard">
         <section class="study-hero app-card">
@@ -115,12 +124,13 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { BookOpenIcon, CheckCircle2Icon, ChevronRightIcon, SearchIcon } from 'lucide-vue-next';
+import { BookOpenIcon, CheckCircle2Icon, ChevronRightIcon, RefreshCwIcon, SearchIcon } from 'lucide-vue-next';
 import { initializeTutorRuntime } from '@/composition-root/public';
 import {
   studyLectureDisplayTitle,
   studyService,
   type StudyDashboard,
+  type StudyLectureEntry,
   type StudyLectureSummary,
   type StudyPoint
 } from '@/services/StudyService';
@@ -150,6 +160,10 @@ const isDispatching = ref(false);
 const isCompleting = ref(false);
 const lectureCompleted = ref(false);
 const loadedCapabilityNodeId = ref('');
+// Identity of the lecture on screen, so "换一版讲义" can re-request the same
+// knowledge point without routing back through the dashboard.
+const loadedModule = ref('');
+const loadedTopic = ref('');
 
 const dailyPlanItemId = computed(() => typeof route.query.dailyPlanItemId === 'string' ? route.query.dailyPlanItemId : '');
 const capabilityNodeId = computed(() => typeof route.query.capabilityNodeId === 'string' ? route.query.capabilityNodeId : '');
@@ -207,6 +221,8 @@ async function load() {
     lectureTitle.value = '';
     lectureCompleted.value = false;
     loadedCapabilityNodeId.value = '';
+    loadedModule.value = '';
+    loadedTopic.value = '';
     const assetId = typeof route.query.assetId === 'string' ? route.query.assetId : '';
     if (assetId) {
       const runtime = await initializeTutorRuntime();
@@ -225,6 +241,8 @@ async function load() {
         ? asset.payload.capabilityNodeId
         : capabilityNodeId.value || undefined;
       loadedCapabilityNodeId.value = assetCapabilityNodeId || '';
+      loadedModule.value = sourceModule;
+      loadedTopic.value = typeof asset?.payload.topic === 'string' ? asset.payload.topic : '';
       if (lectureContent.value) {
         const progress = await studyService.markLectureStarted({
           assetId,
@@ -251,17 +269,52 @@ async function load() {
   }
 }
 
+/**
+ * Routes the outcome of a lecture request. An already written lecture is
+ * opened straight away; only a genuinely new one falls through to the task UI.
+ */
+async function presentLectureEntry(entry: StudyLectureEntry, replace = false): Promise<void> {
+  if (entry.kind === 'ready') {
+    await openLecture(entry.assetId, entry.capabilityNodeId, { replace });
+    return;
+  }
+  trackedTaskId.value = entry.task.id;
+  taskSnapshot.value = entry.task;
+  await taskCenter.refresh();
+}
+
 async function startPlanLecture() {
   if (isDispatching.value || visibleTask.value?.isActive || !dailyPlanItemId.value) return;
   isDispatching.value = true;
   try {
-    const result = await studyService.startDailyPlanLecture({
+    await presentLectureEntry(await studyService.startDailyPlanLecture({
       dailyPlanItemId: dailyPlanItemId.value,
       capabilityNodeId: capabilityNodeId.value || undefined
-    });
-    trackedTaskId.value = result.task.id;
-    taskSnapshot.value = result.task;
-    await taskCenter.refresh();
+    }), true);
+  } finally {
+    isDispatching.value = false;
+  }
+}
+
+/** Deliberate opt-in to spending a generation on a point that already has one. */
+async function regenerateLecture() {
+  if (isDispatching.value || !loadedTopic.value) return;
+  isDispatching.value = true;
+  try {
+    await presentLectureEntry(await studyService.startLearning(
+      {
+        module: loadedModule.value || undefined,
+        name: loadedTopic.value,
+        capabilityNodeId: loadedCapabilityNodeId.value || undefined
+      },
+      dailyPlanItemId.value
+        ? {
+            dailyPlanItemId: dailyPlanItemId.value,
+            capabilityNodeId: loadedCapabilityNodeId.value || undefined
+          }
+        : undefined,
+      { regenerate: true }
+    ), true);
   } finally {
     isDispatching.value = false;
   }
@@ -293,11 +346,22 @@ async function completeLecture() {
   }
 }
 
-async function openLecture(assetId: string, capabilityNodeId?: string) {
-  await router.push({
+/** Single way into a stored lecture, so plan linkage is never dropped en route. */
+async function openLecture(
+  assetId: string,
+  capabilityNode?: string,
+  options: { readonly replace?: boolean } = {}
+) {
+  const target = {
     path: '/vue/study/lecture',
-    query: { assetId, ...(capabilityNodeId ? { capabilityNodeId } : {}) }
-  });
+    query: {
+      assetId,
+      ...(dailyPlanItemId.value ? { dailyPlanItemId: dailyPlanItemId.value } : {}),
+      ...(capabilityNode ? { capabilityNodeId: capabilityNode } : {}),
+      ...(typeof route.query.source === 'string' ? { source: route.query.source } : {})
+    }
+  };
+  await (options.replace ? router.replace(target) : router.push(target));
 }
 
 function formatLectureTime(value: number): string {
@@ -315,19 +379,16 @@ function toggle(moduleName: string) {
 }
 
 async function learn(point: StudyPoint) {
-  const result = await studyService.startLearning(point);
-  trackedTaskId.value = result.task.id;
-  taskSnapshot.value = result.task;
   query.value = point.name;
-  await taskCenter.refresh();
+  await presentLectureEntry(await studyService.startLearning(point));
 }
 
 async function learnQuery() {
   if (!query.value) return;
-  const result = await studyService.startLearning({ module: activeModule.value || undefined, name: query.value });
-  trackedTaskId.value = result.task.id;
-  taskSnapshot.value = result.task;
-  await taskCenter.refresh();
+  await presentLectureEntry(await studyService.startLearning({
+    module: activeModule.value || undefined,
+    name: query.value
+  }));
 }
 
 </script>
@@ -383,6 +444,9 @@ async function learnQuery() {
 .tree-group button { max-width:100%; min-height:31px; padding:0 10px; border:0; border-radius:9px; background:rgba(var(--color-ink-rgb), .06); color:var(--text-color); font-size: var(--type-size-caption); font-weight: var(--type-weight-semibold); font-family: inherit; }
 .tree-group span { display:inline-flex; align-items:center; justify-content:center; min-width:15px; height:15px; margin-left:4px; padding:0 4px; border-radius:8px; background:#dc2626; color:#fff; font-size: var(--type-size-micro); }
 .complete-learning-button { align-self:center; min-height:40px; border:0; border-radius:20px; padding:0 18px; display:inline-flex; align-items:center; gap:7px; background:rgba(var(--color-brand-rgb),.13); color:var(--primary-color); font:inherit; font-size:var(--type-size-secondary); font-weight:var(--type-weight-semibold); }
-.complete-learning-button svg,.completion-notice svg { width:16px; height:16px; }
+.complete-learning-button svg,.completion-notice svg,.regenerate-lecture-button svg { width:16px; height:16px; }
+/* Secondary to 完成本节: regenerating is the deliberate exception, not the default. */
+.regenerate-lecture-button { align-self:center; min-height:36px; border:0; border-radius:18px; padding:0 14px; display:inline-flex; align-items:center; gap:6px; background:transparent; color:var(--text-secondary-color); font:inherit; font-size:var(--type-size-caption); }
+.regenerate-lecture-button:disabled { opacity:.55; }
 .completion-notice { margin:0; display:flex; align-items:center; justify-content:center; gap:7px; color:var(--primary-color); font-size:var(--type-size-caption); }
 </style>


### PR DESCRIPTION
## Summary
- Fix Markdown table rendering so lectures no longer fall back to escaped plain text.
- Add validated statistical chart blocks and responsive table rendering.
- Centralize generated material authoring/parsing and strengthen schema validation.
- Reuse ready lectures by canonical knowledge-point identity with explicit regeneration.
- Preserve cached root-tab content during background refresh.
- Add consistent question-set retirement infrastructure while keeping swipe-delete page triggers disabled.

## Root cause
The custom Marked table renderer was bound before Marked injected its parser context. A Markdown table therefore threw during rendering, both render attempts failed, and the entire lecture was escaped as plain text, exposing raw headings and table syntax.

## Validation
- npm --prefix web run check:content-schema
- npm --prefix web run typecheck
- npm --prefix web run check:code-quality
- npm --prefix web run build
- node scripts/smoke-vue-mobile.js

Closes #26

## Dependency
This PR is stacked on #25. Merge #25 first, or retarget this PR to main after #25 lands.